### PR TITLE
Add list of supported JDKs to test against using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: java
-
+jdk:
+  - openjdk6
+  - openjdk7
+  - oraclejdk7


### PR DESCRIPTION
TravisCI can test against three different JDKs, OpenJDK6, along with OracleJDK7 and OpenJDK7.

This pull request enables them all specifically.

See the docs page for more information:

http://about.travis-ci.org/docs/user/languages/java/
