### PR TITLE
GITHUB-29 : Add profile IRIs

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2DLProfile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2DLProfile.java
@@ -104,6 +104,11 @@ public class OWL2DLProfile implements OWLProfile {
     }
 
     @Override
+    public IRI getIRI() {
+        return OWL2_DL;
+    }
+
+    @Override
     public OWLProfileReport checkOntology(OWLOntology ontology) {
         OWL2Profile owl2Profile = new OWL2Profile();
         OWLProfileReport report = owl2Profile.checkOntology(ontology);

--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2ELProfile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2ELProfile.java
@@ -124,6 +124,11 @@ public class OWL2ELProfile implements OWLProfile {
     }
 
     @Override
+    public IRI getIRI() {
+        return OWL2_EL;
+    }
+
+    @Override
     public OWLProfileReport checkOntology(OWLOntology ontology) {
         OWL2DLProfile profile = new OWL2DLProfile();
         OWLProfileReport report = profile.checkOntology(ontology);

--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2Profile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2Profile.java
@@ -72,6 +72,12 @@ public class OWL2Profile implements OWLProfile {
     }
 
     @Override
+    public IRI getIRI() {
+        // FIXME: The javadoc says this is an OWL2-DL profile, but it does not contain the same restrictions as OWL2DLProfile
+        return OWL2_FULL;
+    }
+
+    @Override
     public OWLProfileReport checkOntology(OWLOntology ontology) {
         OWLOntologyWalker walker = new OWLOntologyWalker(ontology.getImportsClosure());
         OWL2ProfileObjectWalker visitor = new OWL2ProfileObjectWalker(walker, ontology.getOWLOntologyManager());

--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2QLProfile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2QLProfile.java
@@ -133,6 +133,11 @@ public class OWL2QLProfile implements OWLProfile {
     }
 
     @Override
+    public IRI getIRI() {
+        return OWL2_QL;
+    }
+
+    @Override
     public OWLProfileReport checkOntology(OWLOntology ontology) {
         OWL2DLProfile profile = new OWL2DLProfile();
         OWLProfileReport report = profile.checkOntology(ontology);

--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2RLProfile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWL2RLProfile.java
@@ -134,6 +134,11 @@ public class OWL2RLProfile implements OWLProfile {
     }
 
     @Override
+    public IRI getIRI() {
+        return OWL2_RL;
+    }
+
+    @Override
     public OWLProfileReport checkOntology(OWLOntology ontology) {
         OWL2DLProfile profile = new OWL2DLProfile();
         OWLProfileReport report = profile.checkOntology(ontology);

--- a/api/src/main/java/org/semanticweb/owlapi/profiles/OWLProfile.java
+++ b/api/src/main/java/org/semanticweb/owlapi/profiles/OWLProfile.java
@@ -39,6 +39,7 @@
 
 package org.semanticweb.owlapi.profiles;
 
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntology;
 
 
@@ -51,12 +52,37 @@ import org.semanticweb.owlapi.model.OWLOntology;
  */
 public interface OWLProfile {
 
+    /** http://www.w3.org/ns/owl-profile/DL **/
+    public static final IRI OWL2_DL = IRI.create("http://www.w3.org/ns/owl-profile/DL");
+    
+    /** http://www.w3.org/ns/owl-profile/EL **/
+    public static final IRI OWL2_EL = IRI.create("http://www.w3.org/ns/owl-profile/EL");
+    
+    /** http://www.w3.org/ns/owl-profile/QL **/
+    public static final IRI OWL2_QL = IRI.create("http://www.w3.org/ns/owl-profile/QL");
+    
+    /** http://www.w3.org/ns/owl-profile/RL **/
+    public static final IRI OWL2_RL = IRI.create("http://www.w3.org/ns/owl-profile/RL");
+    
+    /** http://www.w3.org/ns/owl-profile/Full **/
+    public static final IRI OWL2_FULL = IRI.create("http://www.w3.org/ns/owl-profile/Full");
+    
     /**
      * Gets the name of the profile.
      * @return A string that represents the name of the profile
      */
     String getName();
 
+    /**
+     * The IRI that uniquely identifies this profile. 
+     * 
+     * If this profile is listed at http://www.w3.org/ns/owl-profile/ 
+     * this IRI MUST match the IRI given in the list.
+     * 
+     * @return The IRI that identifies this profile.
+     */
+    IRI getIRI();
+    
 
     /**
      * Checks an ontology and its import closure to see if it is within


### PR DESCRIPTION
This Pull Request adds IRIs to each of the OWLProfile implementations to link them to the list of Unique URIs for OWL Profiles, as listed at:

http://www.w3.org/ns/owl-profile/
