### PR TITLE
add oraclejdk8 early access build to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
+  - oraclejdk8


### PR DESCRIPTION
Add automated testing against oracle jdk8 to verify that owlapi compiles and tests all pass against it (without having to install it locally).

Travis-CI supports testing against the early access builds for jdk8 which are fairly stable now. Currently Travis is testing against build 117 which is only a few weeks old.

Tracking issue at travis-ci is:

https://github.com/travis-ci/travis-ci/issues/1330
