### PR TITLE
Separate commit of noisy triple logger.

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -1458,7 +1458,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
 
     @Override
     public void startModel(IRI string) {
-        tripleLogger = new TripleLogger();
+        tripleLogger = new TripleLogger(ontologyFormat == null ? null: ontologyFormat.asPrefixOWLOntologyFormat());
     }
 
     /**
@@ -1598,7 +1598,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
     @Override
     public void statementWithLiteralValue(String subject, String predicate,
             String object, String lang, String datatype) {
-        tripleLogger.logTriple(subject,predicate,object);
+        tripleLogger.logLiteralTriple(subject,predicate,object);
         IRI subjectIRI = getIRI(subject);
         IRI predicateIRI = getIRI(predicate);
         predicateIRI = getSynonym(predicateIRI);
@@ -1609,7 +1609,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
     @Override
     public void statementWithLiteralValue(IRI subject, IRI predicate,
             String object, String lang, IRI datatype) {
-        tripleLogger.logTriple(subject,predicate,object);
+        tripleLogger.logLiteralTriple(subject,predicate,object);
         handlerAccessor.handleStreaming(subject, getSynonym(predicate), object,
                 datatype, lang);
     }
@@ -1617,7 +1617,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
     @Override
     public void statementWithResourceValue(String subject, String predicate,
             String object) {
-        tripleLogger.logTriple(subject,predicate,object);
+        tripleLogger.logResourceTriple(subject,predicate,object);
         IRI subjectIRI = getIRI(subject);
         IRI predicateIRI = getIRI(predicate);
         predicateIRI = getSynonym(predicateIRI);
@@ -1628,7 +1628,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
     @Override
     public void statementWithResourceValue(IRI subject, IRI predicate,
             IRI object) {
-        tripleLogger.logTriple(subject,predicate,object);
+        tripleLogger.logResourceTriple(subject,predicate,object);
         handlerAccessor.handleStreaming(subject, getSynonym(predicate),
                 getSynonym(object));
     }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleLogger.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleLogger.java
@@ -1,6 +1,8 @@
 package org.semanticweb.owlapi.rdf.rdfxml.parser;
 
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLOntologyID;
+import org.semanticweb.owlapi.model.PrefixManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,15 +19,17 @@ public class TripleLogger {
     /**
      * The Constant log.
      */
+    private final PrefixManager prefixManager;
     private final Logger log;
     // Debug stuff
     private int count = 0;
 
-    public TripleLogger() {
-        this(LoggerFactory.getLogger(TripleLogger.class));
+    public TripleLogger(PrefixManager prefixManager) {
+        this(LoggerFactory.getLogger(TripleLogger.class), prefixManager);
     }
 
-    public TripleLogger(@Nonnull Logger log) {
+    public TripleLogger(@Nonnull Logger log, PrefixManager prefixManager) {
+        this.prefixManager = prefixManager;
         this.log = log;
     }
 
@@ -36,9 +40,31 @@ public class TripleLogger {
         return count;
     }
 
-    synchronized public void logTriple(Object s, Object p, Object o) {
-        log.trace("s={} p={} o={}", s, p, o);
-        incrementTripleCount();
+    synchronized public void logResourceTriple(String s, String p, String o) {
+        if (log.isTraceEnabled()) {
+            logResourceTriple(IRI.create(s), IRI.create(p), IRI.create(o));
+        }
+    }
+
+    synchronized public void logResourceTriple(IRI s, IRI p, IRI o) {
+        if (log.isTraceEnabled()) {
+            log.trace("{} {} {}.", shorten(s), shorten(p), shorten(o));
+            incrementTripleCount();
+        }
+    }
+
+
+    synchronized public void logLiteralTriple(String s, String p, String o) {
+        if (log.isTraceEnabled()) {
+            logLiteralTriple(IRI.create(s), IRI.create(p), o);
+        }
+    }
+
+    synchronized public void logLiteralTriple(IRI s, IRI p, String o) {
+        if (log.isTraceEnabled()) {
+            log.trace("{} {} \"{}\".", shorten(s), shorten(p), o);
+            incrementTripleCount();
+        }
     }
 
     /**
@@ -64,4 +90,17 @@ public class TripleLogger {
     synchronized public void logOntologyID(OWLOntologyID id) {
         log.debug("Loaded {}", id);
     }
+
+    private String shorten(IRI iri) {
+        if (prefixManager == null) {
+            return iri.toQuotedString();
+        } else {
+            String result = prefixManager.getPrefixIRI(iri);
+            if (result == null) {
+                result = iri.toQuotedString();
+            }
+            return result;
+        }
+    }
+
 }


### PR DESCRIPTION
Constructor provided to allow for an slf4j Logger to be passed in;  not currently used, as meaningful use would require  published api access to OWLRDFConsumer.
