### PR TITLE
Utf 8 test case problem

### DIFF
--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/Utf8TestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/Utf8TestCase.java
@@ -17,6 +17,8 @@ import static org.semanticweb.owlapi.apibinding.OWLFunctionalSyntaxFactory.*;
 import static org.semanticweb.owlapi.search.Searcher.annotations;
 
 import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.junit.Test;
 import org.semanticweb.owlapi.api.test.baseclasses.TestBase;
@@ -64,14 +66,15 @@ public class Utf8TestCase extends TestBase {
                 + "xmlns:xsd =\"http://www.w3.org/2001/XMLSchema#\" \n"
                 + "xmlns:ibs =\"http://www.example.org/ISA14#\" >\n"
                 + "<owl:Ontology rdf:about=\"#\" />\n"
-                + (char) Integer.valueOf("240", 8).intValue()
+                + (char) 0240
                 + "<owl:Class rdf:about=\"http://www.example.org/ISA14#Researcher\"/>\n"
                 + "</rdf:RDF>";
-        ByteArrayInputStream in = new ByteArrayInputStream(onto.getBytes());
+        Charset charset = StandardCharsets.ISO_8859_1;
+        ByteArrayInputStream in = new ByteArrayInputStream(onto.getBytes(charset));
         try {
             m.loadOntologyFromOntologyDocument(in);
             fail("parsing should have failed, invalid input");
-        } catch (Throwable ex) {
+        } catch (Exception ex) {
             // expected to fail, but actual exception depends on the parsers in
             // the classpath
         }


### PR DESCRIPTION
Utf8TestCase::testInvalidUTF8roundTrip has two errors.

1) String::getBytes is called with no arguments, which uses the default charset encoder to generate an octet stream.
   With a default charset of UTF-8, this results in a valid UTF-8 octet stream.
   Unfix lack of error by bytes as ISO_8859_1.

 2) The call to loadOntologyFromOntologyDocument was succeeding on the valid UTF-8 stream, and hitting
 the fail statement.  Unfortunately, the catch block was catching Throwable, rather than Exception.  Since Throwable is a superclass of the AssertionError thrown by fail, the call to fail to indicate a failure to fail was getting caught as if the method had successfully failed. (Prime Minister).

 With these changes in place, the bad octet in the UTF-8 stream is detected and an  exception  is thrown.
