### PR TITLE
Set turtle default prefix slash aware

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
@@ -78,7 +78,12 @@ public class TurtleRenderer extends RDFRendererBase {
         pending = new HashSet<RDFResource>();
         pm = new DefaultPrefixManager();
         if (!ontology.isAnonymous()) {
-            pm.setDefaultPrefix(ontology.getOntologyID().getOntologyIRI() + "#");
+            String ontologyIRIString = ontology.getOntologyID().getOntologyIRI().toString();
+            String defaultPrefix = ontologyIRIString;
+            if(!ontologyIRIString.endsWith("/")) {
+                 defaultPrefix = ontologyIRIString + "#";
+            }
+            pm.setDefaultPrefix(defaultPrefix);
         }
         if (format instanceof PrefixOWLOntologyFormat) {
             PrefixOWLOntologyFormat prefixFormat = (PrefixOWLOntologyFormat) format;


### PR DESCRIPTION
If the Ontology IRI ends in /, the TurtleRenderer was still appending a '#' when creating the default prefix. 

This may or may not be cool
