### PR TITLE
Remove no argument constructor from OwlOntologyChangeRecord.

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/change/OWLOntologyChangeRecord.java
+++ b/api/src/main/java/org/semanticweb/owlapi/change/OWLOntologyChangeRecord.java
@@ -61,12 +61,6 @@ public class OWLOntologyChangeRecord<T> implements Serializable {
     private final OWLOntologyID ontologyID;
     private final OWLOntologyChangeData<T> data;
 
-    /** Default constructor for serialization purposes only. */
-    @SuppressWarnings("unused")
-    private OWLOntologyChangeRecord() {
-        ontologyID = null;
-        data = null;
-    }
 
     /**
      * Constructs an {@link OWLOntologyChangeRecord} object which holds

--- a/api/src/test/java/org/semanticweb/owlapi/change/OWLOntologyChangeRecordTest.java
+++ b/api/src/test/java/org/semanticweb/owlapi/change/OWLOntologyChangeRecordTest.java
@@ -1,0 +1,32 @@
+package org.semanticweb.owlapi.change;
+
+import org.junit.Test;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyID;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+
+import static org.junit.Assert.*;
+
+public class OWLOntologyChangeRecordTest {
+
+    @Test public void testSerializeChangeRecord() throws IOException, ClassNotFoundException {
+        OWLOntologyID id1 = new OWLOntologyID(IRI.create("urn:a"),IRI.create("urn:v1"));
+        OWLOntologyID id2 = new OWLOntologyID(IRI.create("urn:a"),IRI.create("urn:v2"));
+        OWLOntologyChangeRecord<OWLOntologyID>  idChangeRecord = new OWLOntologyChangeRecord<OWLOntologyID>(id1,new SetOntologyIDData(id2));
+
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+        ObjectOutputStream out = new ObjectOutputStream(byteArrayOutputStream);
+        out.writeObject(idChangeRecord);
+        out.close();
+
+        ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+        OWLOntologyChangeRecord<OWLOntologyID> recordIn = (OWLOntologyChangeRecord<OWLOntologyID>) in.readObject();
+        assertEquals(idChangeRecord,recordIn);
+    }
+}


### PR DESCRIPTION
Java Serialization only requires a no-arg constructor on the first _non_-Serializable superclass of a serialized Object.
Since OwlOntologyChangeRecord is serializable, it does not need the no-arg constructor.
