### PR TITLE
Change buffering strategy  buffer reader, not input stream

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/io/FileDocumentSource.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/FileDocumentSource.java
@@ -14,6 +14,7 @@ package org.semanticweb.owlapi.io;
 
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -108,7 +109,7 @@ public class FileDocumentSource extends OWLOntologyDocumentSourceBase {
     @Override
     public Reader getReader() {
         try {
-            return new InputStreamReader(getInputStream(), "UTF-8");
+            return new BufferedReader(new InputStreamReader(getInputStream(), "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             // it cannot not support UTF-8
             throw new OWLOntologyInputSourceException(e);

--- a/api/src/main/java/org/semanticweb/owlapi/io/OWLOntologyDocumentSourceBase.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/OWLOntologyDocumentSourceBase.java
@@ -36,7 +36,7 @@ public abstract class OWLOntologyDocumentSourceBase implements
     }
 
     /**
-     * Wrap an input stream in a buffered input stream and strip BOMs.
+     * Wrap an input stream to  strip BOMs.
      * 
      * @param delegate
      *        delegate to wrap
@@ -45,10 +45,10 @@ public abstract class OWLOntologyDocumentSourceBase implements
     @Nonnull
     public static InputStream wrap(@Nonnull InputStream delegate) {
         checkNotNull(delegate, "delegate cannot be null");
-        return new BufferedInputStream(new BOMInputStream(delegate,
+        return new BOMInputStream(delegate,
                 ByteOrderMark.UTF_8, ByteOrderMark.UTF_16BE,
                 ByteOrderMark.UTF_16LE, ByteOrderMark.UTF_32BE,
-                ByteOrderMark.UTF_32LE));
+                ByteOrderMark.UTF_32LE);
     }
 
     private final OWLOntologyFormat format;


### PR DESCRIPTION
Applying buffering to the input stream rather than the reader uses a lot of cpu time in character set decoding. 

This was masked when using JavaCC's streams
