### PR TITLE
RDF-1.1 changes

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -51,8 +51,15 @@ public class RDFLiteral extends RDFNode {
             @Nullable IRI datatype) {
         lexicalValue = checkNotNull(literal, "literal cannot be null");
         this.lang = lang;
-        this.datatype = datatype == null ? OWL2Datatype.RDF_PLAIN_LITERAL
-                .getIRI() : datatype;
+        if (lang == null || lang.isEmpty()) {
+            if (datatype == null) {
+               this.datatype = OWL2Datatype.XSD_STRING.getIRI();
+           } else {
+               this.datatype = datatype;
+           }
+        } else {
+            this.datatype = OWL2Datatype.RDF_LANG_STRING.getIRI();
+        }
     }
 
     /**
@@ -133,7 +140,7 @@ public class RDFLiteral extends RDFNode {
 
     /** @return true if this literal has a non empty lang tag */
     public boolean hasLang() {
-        return !lang.isEmpty();
+        return lang != null && !lang.isEmpty();
     }
 
     /** @return true if the datatype of this literal is plain literal */

--- a/api/src/main/java/org/semanticweb/owlapi/util/SimpleRenderer.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/SimpleRenderer.java
@@ -115,6 +115,7 @@ import org.semanticweb.owlapi.model.SWRLObjectPropertyAtom;
 import org.semanticweb.owlapi.model.SWRLRule;
 import org.semanticweb.owlapi.model.SWRLSameIndividualAtom;
 import org.semanticweb.owlapi.model.SWRLVariable;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 /**
  * A simple renderer that can be used for debugging purposes and provide an
@@ -791,7 +792,7 @@ public class SimpleRenderer implements OWLObjectVisitor, OWLObjectRenderer {
     @Override
     public void visit(OWLLiteral node) {
         String literal = EscapeUtils.escapeString(node.getLiteral());
-        if (node.isRDFPlainLiteral()) {
+        if (node.isRDFPlainLiteral() || node.getDatatype().getIRI().equals(OWL2Datatype.RDF_LANG_STRING.getIRI())) {
             // We can use a syntactic shortcut
             sb.append('"').append(literal).append('"');
             if (node.hasLang()) {

--- a/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
+++ b/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
@@ -60,6 +60,7 @@ public enum OWL2Datatype implements HasIRI, HasShortForm, HasPrefixedName {
     /** RDF_XML_LITERAL */          RDF_XML_LITERAL          (RDF,  "XMLLiteral",   Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"), 
     /** RDFS_LITERAL */             RDFS_LITERAL             (RDFS, "Literal",      Category.CAT_UNIVERSAL,                   false, ".*"),
     /** RDF_PLAIN_LITERAL */        RDF_PLAIN_LITERAL        (RDF,  "PlainLiteral", Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),
+    /** RDF_LANG_STRING */          RDF_LANG_STRING          (RDF,  "langString",   Category.CAT_STRING_WITH_LANGUAGE_TAG,    false, ".*"),
     /** OWL_REAL */                 OWL_REAL                 (OWL,  "real",         Category.CAT_NUMBER,                      false, ".*"),
     /** OWL_RATIONAL */             OWL_RATIONAL             (OWL,  "rational",     Category.CAT_NUMBER,                      false, "(\\+|-)?([0-9]+)(\\s)*(/)(\\s)*([0-9]+)"),
     /** XSD_STRING */               XSD_STRING               (STRING,               Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -77,8 +77,9 @@ public class LiteralTestCase extends AbstractAxiomsRoundTrippingTestCase {
     @Test
     public void testPlainLiteralWithLang() {
         OWLLiteral literalWithLang = Literal("abc", "en");
-        assertTrue(literalWithLang.getDatatype().getIRI().isPlainLiteral());
-        assertTrue(literalWithLang.isRDFPlainLiteral());
+        assertFalse(literalWithLang.getDatatype().getIRI().isPlainLiteral());
+        assertFalse(literalWithLang.isRDFPlainLiteral());
+        assertTrue(literalWithLang.hasLang());
     }
 
     @Test

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -41,12 +41,24 @@ public class LiteralTestCase extends AbstractAxiomsRoundTrippingTestCase {
     @Override
     protected Set<? extends OWLAxiom> createAxioms() {
         OWLLiteral literalWithLang = Literal("abc", "en");
+        OWLLiteral literalWithoutLang = Literal("abcd", "");
+        OWLLiteral literalPlain = Literal("abcde");
+        OWLLiteral literalString = Literal("abcdef", OWL2Datatype.XSD_STRING);
         OWLClass cls = Class(iri("A"));
         OWLAnnotationProperty prop = AnnotationProperty(iri("prop"));
-        OWLAnnotationAssertionAxiom ax = AnnotationAssertion(prop,
+        OWLAnnotationAssertionAxiom ax1 = AnnotationAssertion(prop,
                 cls.getIRI(), literalWithLang);
+        OWLAnnotationAssertionAxiom ax2 = AnnotationAssertion(prop,
+                cls.getIRI(), literalWithoutLang);
+        OWLAnnotationAssertionAxiom ax3 = AnnotationAssertion(prop,
+                cls.getIRI(), literalPlain);
+        OWLAnnotationAssertionAxiom ax4 = AnnotationAssertion(prop,
+                cls.getIRI(), literalString);
         Set<OWLAxiom> axioms = new HashSet<>();
-        axioms.add(ax);
+        axioms.add(ax1);
+        axioms.add(ax2);
+        axioms.add(ax3);
+        axioms.add(ax4);
         axioms.add(Declaration(cls));
         return axioms;
     }
@@ -80,30 +92,36 @@ public class LiteralTestCase extends AbstractAxiomsRoundTrippingTestCase {
         assertFalse(literalWithLang.getDatatype().getIRI().isPlainLiteral());
         assertFalse(literalWithLang.isRDFPlainLiteral());
         assertTrue(literalWithLang.hasLang());
+        assertEquals("en", literalWithLang.getLang());
+        assertEquals(literalWithLang.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     @Test
     public void testPlainLiteralWithEmbeddedLang() {
         OWLLiteral literal = Literal("abc@en", PlainLiteral());
         assertTrue(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("en", literal.getLang());
         assertEquals("abc", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     public void tesPlainLiteralWithEmbeddedEmptyLang() {
         OWLLiteral literal = Literal("abc@", PlainLiteral());
         assertFalse(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("", literal.getLang());
         assertEquals("abc", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.XSD_STRING.getDatatype(df));
     }
 
     public void tesPlainLiteralWithDoubleSep() {
         OWLLiteral literal = Literal("abc@@en", PlainLiteral());
+        assertTrue(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("en", literal.getLang());
         assertEquals("abc@", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     @Test

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
@@ -78,8 +78,10 @@ public class TestPlainLiteralTestCase extends TestBase {
                 m.getOWLDataFactory().getOWLDataPropertyAssertionAxiom(p, i, l));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.saveOntology(o, out);
-        String expected = "<test:p rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</test:p>";
-        assertTrue(out.toString(), out.toString().contains(expected));
+        String expectedStart = "<test:p";
+        String expectedEnd = ">test</test:p>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 
     @Test
@@ -92,8 +94,10 @@ public class TestPlainLiteralTestCase extends TestBase {
                 .asOWLNamedIndividual().getIRI(), l));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.saveOntology(o, out);
-        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
-        assertTrue(out.toString(), out.toString().contains(expected));
+        String expectedStart = "<rdfs:comment";
+   		String expectedEnd = ">test</rdfs:comment>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 
     @Test
@@ -106,7 +110,9 @@ public class TestPlainLiteralTestCase extends TestBase {
         m.applyChange(new AddOntologyAnnotation(o, a));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.saveOntology(o, out);
-        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
-        assertTrue(out.toString(), out.toString().contains(expected));
+        String expectedStart = "<rdfs:comment";
+        String expectedEnd = ">test</rdfs:comment>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
@@ -78,7 +78,7 @@ public class TestPlainLiteralTestCase extends TestBase {
                 m.getOWLDataFactory().getOWLDataPropertyAssertionAxiom(p, i, l));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.saveOntology(o, out);
-        String expected = "<test:p>test</test:p>";
+        String expected = "<test:p rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</test:p>";
         assertTrue(out.toString(), out.toString().contains(expected));
     }
 
@@ -90,8 +90,10 @@ public class TestPlainLiteralTestCase extends TestBase {
                 OWL2Datatype.RDF_PLAIN_LITERAL);
         m.addAxiom(o, df.getOWLAnnotationAssertionAxiom(df.getRDFSComment(), i
                 .asOWLNamedIndividual().getIRI(), l));
-        String expected = "<rdfs:comment>test</rdfs:comment>";
-        assertTrue(saveOntology(o).toString().contains(expected));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        m.saveOntology(o, out);
+        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
+        assertTrue(out.toString(), out.toString().contains(expected));
     }
 
     @Test
@@ -104,7 +106,7 @@ public class TestPlainLiteralTestCase extends TestBase {
         m.applyChange(new AddOntologyAnnotation(o, a));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         m.saveOntology(o, out);
-        String expected = "<rdfs:comment>test</rdfs:comment>";
+        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
         assertTrue(out.toString(), out.toString().contains(expected));
     }
 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserTestCase.java
@@ -400,10 +400,7 @@ public class ManchesterOWLSyntaxParserTestCase extends TestBase {
                 + "AnnotationAssertion(Annotation(<http://x.org/p2> \"foo\") <http://x.org/p> <http://x.org/c> \"v1\"))";
         OWLOntology o = loadOntologyFromString(in);
         OWLOntology result = roundTrip(o, new ManchesterSyntaxDocumentFormat());
-        for (OWLAxiom ax : o.getAxioms()) {
-            assert ax != null;
-            assertTrue(result.containsAxiom(ax));
-        }
+        equal(o, result);
     }
 
     @Test

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalsNoCache.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalsNoCache.java
@@ -38,6 +38,9 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
     private static final OWLDatatype PLAIN = new OWL2DatatypeImpl(
             RDF_PLAIN_LITERAL);
     @Nonnull
+    private static final OWLDatatype LANGSTRING = new OWL2DatatypeImpl(
+            RDF_LANG_STRING);
+    @Nonnull
     private static final OWLDatatype XSDBOOLEAN = new OWL2DatatypeImpl(
             XSD_BOOLEAN);
     @Nonnull
@@ -48,6 +51,9 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
     @Nonnull
     private static final OWLDatatype XSDINTEGER = new OWL2DatatypeImpl(
             XSD_INTEGER);
+    @Nonnull
+    private static final OWLDatatype XSDSTRING = new OWL2DatatypeImpl(
+            XSD_STRING);
     @Nonnull
     private static final OWLDatatype RDFSLITERAL = new OWL2DatatypeImpl(
             RDFS_LITERAL);
@@ -150,14 +156,14 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
     public OWLLiteral getOWLLiteral(@Nonnull String lexicalValue,
             @Nonnull OWLDatatype datatype) {
         OWLLiteral literal;
-        if (datatype.isRDFPlainLiteral()) {
+        if (datatype.isRDFPlainLiteral() || datatype.equals(LANGSTRING)) {
             int sep = lexicalValue.lastIndexOf('@');
             if (sep != -1) {
                 String lex = lexicalValue.substring(0, sep);
                 String lang = lexicalValue.substring(sep + 1);
-                literal = getBasicLiteral(lex, lang, getRDFPlainLiteral());
+                literal = getBasicLiteral(lex, lang, LANGSTRING);
             } else {
-                literal = getBasicLiteral(lexicalValue, datatype);
+                literal = getBasicLiteral(lexicalValue, XSDSTRING);
             }
         } else {
             // check the special cases
@@ -225,7 +231,7 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
             String lang, OWLDatatype datatype) {
         OWLLiteral literal = null;
         if (useCompression) {
-            if (datatype == null || datatype.isRDFPlainLiteral()) {
+            if (datatype == null || datatype.isRDFPlainLiteral() || datatype.equals(RDF_LANG_STRING)) {
                 literal = new OWLLiteralImplPlain(lexicalValue, lang);
             } else {
                 literal = new OWLLiteralImpl(lexicalValue, lang, datatype);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalsNoCache.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalsNoCache.java
@@ -116,8 +116,7 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
     @Override
     public OWLLiteral getOWLLiteral(@Nonnull String value) {
         if (useCompression) {
-            return new OWLLiteralImpl(value, "",
-                    getOWLDatatype(XSDVocabulary.STRING.getIRI()));
+            return new OWLLiteralImpl(value, "", XSDSTRING);
         }
         return new OWLLiteralImplString(value);
     }
@@ -130,10 +129,17 @@ public class InternalsNoCache implements OWLDataFactoryInternals, Serializable {
         } else {
             normalisedLang = lang.trim().toLowerCase(Locale.ENGLISH);
         }
-        if (useCompression) {
-            return new OWLLiteralImpl(literal, normalisedLang, null);
+        if (normalisedLang.isEmpty()) {
+            if (useCompression) {
+                return new OWLLiteralImpl(literal, null, XSDSTRING);
+            }
+            return new OWLLiteralImplString(literal);
+        } else {
+            if (useCompression) {
+                return new OWLLiteralImpl(literal, normalisedLang, null);
+            }
+            return new OWLLiteralImplPlain(literal, normalisedLang);
         }
-        return new OWLLiteralImplPlain(literal, normalisedLang);
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -91,15 +91,15 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
                 "literal cannot be null"));
         if (lang == null || lang.isEmpty()) {
             language = "";
-            if (datatype == null) {
+            if (datatype == null || datatype.equals(RDF_PLAIN_LITERAL) || datatype.equals(XSD_STRING)) {
                 this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
         } else {
-            if (datatype != null && !datatype.isRDFPlainLiteral()) {
+            if (datatype != null && !(datatype.equals(RDF_LANG_STRING) || datatype.equals(RDF_PLAIN_LITERAL))) {
                 // ERROR: attempting to build a literal with a language tag and
-                // type different from plain literal
+                // type different from plain literal or lang string
                 throw new OWLRuntimeException(
                         "Error: cannot build a literal with type: "
                                 + datatype.getIRI() + " and language: " + lang);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -59,6 +59,12 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
     private static final OWLDatatype RDF_PLAIN_LITERAL = new OWL2DatatypeImpl(
             OWL2Datatype.RDF_PLAIN_LITERAL);
     @Nonnull
+    private static final OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.RDF_LANG_STRING);
+    @Nonnull
+    private static final OWLDatatype XSD_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.XSD_STRING);
+    @Nonnull
     private final OWLDatatype datatype;
     @Nonnull
     private final String language;
@@ -86,7 +92,7 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
         if (lang == null || lang.isEmpty()) {
             language = "";
             if (datatype == null) {
-                this.datatype = RDF_PLAIN_LITERAL;
+                this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
@@ -99,7 +105,7 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
                                 + datatype.getIRI() + " and language: " + lang);
             }
             language = lang;
-            this.datatype = RDF_PLAIN_LITERAL;
+            this.datatype = RDF_LANG_STRING;
         }
         hashcode = getHashCode();
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
@@ -41,6 +41,12 @@ public class OWLLiteralImplNoCompression extends OWLObjectImpl implements
     private static final OWLDatatype RDF_PLAIN_LITERAL = new OWL2DatatypeImpl(
             OWL2Datatype.RDF_PLAIN_LITERAL);
     @Nonnull
+    private static final OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.RDF_LANG_STRING);
+    @Nonnull
+    private static final OWLDatatype XSD_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.XSD_STRING);
+    @Nonnull
     private final String literal;
     @Nonnull
     private final OWLDatatype datatype;
@@ -67,20 +73,20 @@ public class OWLLiteralImplNoCompression extends OWLObjectImpl implements
         if (lang == null || lang.isEmpty()) {
             language = "";
             if (datatype == null) {
-                this.datatype = RDF_PLAIN_LITERAL;
+                this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
         } else {
-            if (datatype != null && !datatype.isRDFPlainLiteral()) {
+            if (datatype != null && !(datatype.equals(RDF_LANG_STRING) || datatype.equals(RDF_PLAIN_LITERAL))) {
                 // ERROR: attempting to build a literal with a language tag and
-                // type different from plain literal
+                // type different from RDF_LANG_STRING or RDF_PLAIN_LITERAL
                 throw new OWLRuntimeException(
                         "Error: cannot build a literal with type: "
                                 + datatype.getIRI() + " and language: " + lang);
             }
             language = lang;
-            this.datatype = RDF_PLAIN_LITERAL;
+            this.datatype = RDF_LANG_STRING;
         }
         hashcode = getHashCode();
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -62,11 +62,11 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
      */
     public OWLLiteralImplPlain(@Nonnull String literal, @Nullable String lang) {
         this.literal = literal;
-        if (lang == null || lang.length() == 0) {
+        if (lang == null || lang.isEmpty()) {
             this.lang = "";
             this.datatype = XSD_STRING;
         } else {
-            this.lang = lang;
+            this.lang = lang.trim();
             this.datatype = RDF_LANG_STRING;
         }
         hashcode = getHashCode();
@@ -84,7 +84,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public boolean hasLang() {
-        return !lang.equals("");
+        return !lang.isEmpty();
     }
 
     @Override
@@ -193,10 +193,6 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
                 return false;
             }
             OWLLiteral other = (OWLLiteral) obj;
-            if (other instanceof OWLLiteralImplPlain) {
-                return literal.equals(((OWLLiteralImplPlain) other).literal)
-                        && lang.equals(other.getLang());
-            }
             return getLiteral().equals(other.getLiteral())
                     && getDatatype().equals(other.getDatatype())
                     && lang.equals(other.getLang());
@@ -231,11 +227,11 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
         if (diff != 0) {
             return diff;
         }
-        diff = getDatatype().compareTo(other.getDatatype());
-        if (diff != 0) {
+        diff = lang.compareToIgnoreCase(other.getLang());
+        if(diff != 0) {
             return diff;
         }
-        return lang.compareTo(other.getLang());
+        return getDatatype().compareTo(other.getDatatype());
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -29,7 +29,7 @@ import org.semanticweb.owlapi.util.OWLObjectTypeIndexProvider;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 /**
- * An OWLLiteral whose datatype is RDF_PLAIN_LITERAL
+ * An OWLLiteral whose datatype is RDF_LANG_STRING or XSD_STRING
  * 
  * @author Matthew Horridge, The University Of Manchester, Bio-Health
  *         Informatics Group, Date: 26-Oct-2006
@@ -41,7 +41,15 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
     private static final OWLDatatype RDF_PLAIN_LITERAL = new OWL2DatatypeImpl(
             OWL2Datatype.RDF_PLAIN_LITERAL);
     @Nonnull
+    private static final OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.RDF_LANG_STRING);
+    @Nonnull
+    private static final OWLDatatype XSD_STRING = new OWL2DatatypeImpl(
+            OWL2Datatype.XSD_STRING);
+    @Nonnull
     private final String literal;
+    @Nonnull
+    private final OWLDatatype datatype;
     @Nonnull
     private final String lang;
     private final int hashcode;
@@ -56,8 +64,10 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
         this.literal = literal;
         if (lang == null || lang.length() == 0) {
             this.lang = "";
+            this.datatype = XSD_STRING;
         } else {
             this.lang = lang;
+            this.datatype = RDF_LANG_STRING;
         }
         hashcode = getHashCode();
     }
@@ -84,7 +94,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public boolean isRDFPlainLiteral() {
-        return true;
+        return false;
     }
 
     @Override
@@ -140,7 +150,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public OWLDatatype getDatatype() {
-        return RDF_PLAIN_LITERAL;
+        return this.datatype;
     }
 
     @Override

--- a/parsers/src/main/java/org/semanticweb/owlapi/owlxml/parser/PARSER_OWLXMLVocabulary.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/owlxml/parser/PARSER_OWLXMLVocabulary.java
@@ -62,6 +62,7 @@ import org.semanticweb.owlapi.model.SWRLVariable;
 import org.semanticweb.owlapi.model.SetOntologyID;
 import org.semanticweb.owlapi.model.UnloadableImportException;
 import org.semanticweb.owlapi.vocab.Namespaces;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import org.semanticweb.owlapi.vocab.OWLFacet;
 import org.semanticweb.owlapi.vocab.OWLXMLVocabulary;
 
@@ -2240,7 +2241,7 @@ class OWLLiteralElementHandler extends OWLElementHandler<OWLLiteral> {
 
     @Override
     void endElement() {
-        if (iri != null && !iri.isPlainLiteral()) {
+        if (iri != null && !(iri.isPlainLiteral() || iri.equals(OWL2Datatype.RDF_LANG_STRING.getIRI()))) {
             literal = df.getOWLLiteral(getText(),
                     df.getOWLDatatype(verifyNotNull(iri)));
         } else {

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -1667,11 +1667,13 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker {
     @Nonnull
     OWLLiteral getOWLLiteral(@Nonnull String literal, @Nullable IRI datatype,
             @Nullable String lang) {
-        if (datatype != null) {
+        if (lang != null && !lang.trim().isEmpty()) {
+            return dataFactory.getOWLLiteral(literal, lang);
+        } else if (datatype != null) {
             return dataFactory.getOWLLiteral(literal,
                     dataFactory.getOWLDatatype(datatype));
         } else {
-            return dataFactory.getOWLLiteral(literal, lang);
+            return dataFactory.getOWLLiteral(literal);
         }
     }
 

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
@@ -256,12 +256,12 @@ public class RDFXMLRenderer extends RDFRendererBase {
                 }
             } else {
                 RDFLiteral rdfLiteralNode = (RDFLiteral) objectNode;
-                if (!rdfLiteralNode.isPlainLiteral()) {
-                    writer.writeDatatypeAttribute(rdfLiteralNode.getDatatype());
-                } else if (rdfLiteralNode.hasLang()) {
+                if (rdfLiteralNode.hasLang()) {
                     writer.writeLangAttribute(rdfLiteralNode.getLang());
+                } else if (!rdfLiteralNode.isPlainLiteral()) {
+                    writer.writeDatatypeAttribute(rdfLiteralNode.getDatatype());
                 }
-                writer.writeTextContent(rdfLiteralNode.getLexicalValue());
+               	writer.writeTextContent(rdfLiteralNode.getLexicalValue());
             }
             writer.writeEndElement();
         }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
@@ -199,8 +199,13 @@ public class TurtleRenderer extends RDFRendererBase {
                 write(node.getLexicalValue());
             } else {
                 writeStringLiteral(node.getLexicalValue());
-                write("^^");
-                write(node.getDatatype());
+                if (node.hasLang()) {
+                    write("@");
+                    write(node.getLang());
+                } else {
+	                write("^^");
+	                write(node.getDatatype());
+                }
             }
         } else {
             writeStringLiteral(node.getLexicalValue());

--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -13,7 +13,7 @@
 	<description>Extends OWLAPI to export ontologies to any Sesame Rio RDFHandler, including databases and in-memory RDF statement collections.</description>
 	
 	<properties>
-		<sesame.version>2.7.12</sesame.version>
+		<sesame.version>2.8.0-beta2-SNAPSHOT</sesame.version>
 	</properties>
 	
 	<dependencies>

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
@@ -124,9 +124,7 @@ public class RioOWLRDFConsumerAdapter extends OWLRDFConsumer implements
             final Literal literalObject = (Literal) st.getObject();
             String literalDatatype = null;
             final String literalLanguage = literalObject.getLanguage();
-            // TODO: When updating to Sesame-2.8 with RDF-1.1 support, the
-            // following if condition will always be true
-            if (literalObject.getDatatype() != null) {
+            if (literalLanguage == null) {
                 literalDatatype = literalObject.getDatatype().stringValue();
             }
             logger.trace("statement with literal value");

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
@@ -47,6 +47,7 @@ import org.openrdf.model.Statement;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.vocabulary.XMLSchema;
 import org.semanticweb.owlapi.io.RDFLiteral;
 import org.semanticweb.owlapi.io.RDFResourceIRI;
 import org.semanticweb.owlapi.io.RDFTriple;
@@ -128,15 +129,12 @@ public class RioUtils {
             }
         } else if (triple.getObject() instanceof RDFLiteral) {
             final RDFLiteral literalObject = (RDFLiteral) triple.getObject();
-            // TODO: When updating to Sesame-2.8 the following may need to be
-            // rewritten
-            if (literalObject.isPlainLiteral()) {
-                if (literalObject.hasLang()) {
-                    object = vf.createLiteral(literalObject.getLexicalValue(),
-                            literalObject.getLang());
-                } else {
-                    object = vf.createLiteral(literalObject.getLexicalValue());
-                }
+            if (literalObject.hasLang()) {
+                object = vf.createLiteral(literalObject.getLexicalValue(),
+                        literalObject.getLang());
+            } else if (literalObject.getDatatype() == null) {
+                object = vf.createLiteral(literalObject.getLexicalValue(),
+                        XMLSchema.STRING);
             } else {
                 object = vf.createLiteral(literalObject.getLexicalValue(),
                         vf.createURI(literalObject.getDatatype().toString()));


### PR DESCRIPTION
This pull request makes the necessary changes to deprecate rdf:PlainLiteral and replace it with the combination of rdf:langString and xsd:string to match RDF-1.1.

This should be taken in the context of the discussion at various issues, including #172 and #174