### PR TITLE
Fix use of static RDFFormat.valueOf function

### DIFF
--- a/rio/src/main/java/org/semanticweb/owlapi/formats/RioRDFOntologyFormat.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/formats/RioRDFOntologyFormat.java
@@ -47,7 +47,7 @@ public class RioRDFOntologyFormat extends
         org.semanticweb.owlapi.formats.RDFOntologyFormat {
 
     private static final long serialVersionUID = 40000L;
-    private final String formatName;
+    private final RDFFormat format;
 
     /**
      * Constructor for super-classes to specify which {@link RDFFormat} they
@@ -57,19 +57,19 @@ public class RioRDFOntologyFormat extends
      *        The {@link RDFFormat} that this instance supports.
      */
     public RioRDFOntologyFormat(RDFFormat format) {
-        this.formatName = format.getName();
+        this.format = format;
     }
 
     @SuppressWarnings("null")
     @Override
     public String getKey() {
-        return formatName;
+        return format.getName();
     }
 
     /**
      * @return Rio format for this format
      */
     public RDFFormat getRioFormat() {
-        return RDFFormat.valueOf(formatName);
+        return format;
     }
 }


### PR DESCRIPTION
For some reason, the passed in RDFFormat was being converted to a string instead of being stored, which required the use of the deprecated (in Sesame-2.8) RDFFormat.valueOf function to get the constant back.

Although it is better just to store the format directly than to have to regenerate it, it also has implications for third-party formats which are created but may not have been registered with RDFFormat and hence may not come back from RDFFormat.valueOf
