### PR TITLE
Add sesame-bom for dependency version management

### DIFF
--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -13,7 +13,7 @@
 	<description>Extends OWLAPI to export ontologies to any Sesame Rio RDFHandler, including databases and in-memory RDF statement collections.</description>
 	
 	<properties>
-		<sesame.version>2.7.11</sesame.version>
+		<sesame.version>2.7.12</sesame.version>
 	</properties>
 	
 	<dependencies>


### PR DESCRIPTION
The sesame-bom is designed to be used in dependencyManagement to ensure that all sesame dependencies have the same version when the reactor runs.

Also bump to Sesame-2.7.12 as that is the first release containing sesame-bom.
