### PR TITLE
Bump jsonld-java to 0.5.0 release

### DIFF
--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -106,13 +106,13 @@
 		<dependency>
 			<groupId>com.github.jsonld-java</groupId>
 			<artifactId>jsonld-java-sesame</artifactId>
-			<version>0.5-SNAPSHOT</version>
+			<version>0.5.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-		    <groupId>org.semarglproject</groupId>
-		    <artifactId>semargl-sesame</artifactId>
-		    <version>0.6.1</version>
+			<groupId>org.semarglproject</groupId>
+			<artifactId>semargl-sesame</artifactId>
+			<version>0.6.1</version>
 			<scope>runtime</scope>
 		</dependency>
 	</dependencies>


### PR DESCRIPTION
Bump to newly released jsonld-java-0.5.0 version to remove dependency on snapshot. May fail automated TravisCI test as it may not be visible on Maven Central yet.
