### PR TITLE
Change the initial size of the THashSet to 2 instead of 17

### DIFF
--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/MapPointer.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/MapPointer.java
@@ -65,7 +65,7 @@ public class MapPointer<K, V extends OWLAxiom> {
     private THashMap<K, THashSet<V>> map = new THashMap<>(17, 0.75F);
 
     private THashSet<V> set() {
-        return new THashSet<V>(17, 0.75F);
+        return new THashSet<V>(2, 0.75F);
     }
 
     /**


### PR DESCRIPTION
Change the initial size of the THashSet to 2 instead of 17;  this reduces the size of larger maps; there does not appear to be any speed penalty.

 internals size changes
  from 1,035,950,000
     to  0,867,936,416
