### PR TITLE
Provide "trimToSize" methods on MapPointer, Internals, and OWLAxiomIndexImpl

### DIFF
--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/Internals.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/Internals.java
@@ -12,11 +12,16 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package uk.ac.manchester.cs.owl.owlapi;
 
-import static org.semanticweb.owlapi.model.AxiomType.*;
-import static org.semanticweb.owlapi.util.CollectionFactory.*;
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
-import static uk.ac.manchester.cs.owl.owlapi.InitVisitorFactory.*;
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+import org.semanticweb.owlapi.model.*;
+import org.semanticweb.owlapi.model.parameters.Navigation;
+import org.semanticweb.owlapi.util.CollectionFactory;
+import org.semanticweb.owlapi.util.OWLAxiomSearchFilter;
+import org.semanticweb.owlapi.util.OWLAxiomVisitorAdapter;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
@@ -26,73 +31,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAnnotationSubject;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
-import org.semanticweb.owlapi.model.OWLAsymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLAxiomVisitorEx;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLClassAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLClassAxiom;
-import org.semanticweb.owlapi.model.OWLClassExpression;
-import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLDataPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLDataPropertyExpression;
-import org.semanticweb.owlapi.model.OWLDataPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLDatatype;
-import org.semanticweb.owlapi.model.OWLDeclarationAxiom;
-import org.semanticweb.owlapi.model.OWLDifferentIndividualsAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointClassesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointDataPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLDisjointUnionAxiom;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLEntityVisitorEx;
-import org.semanticweb.owlapi.model.OWLEquivalentClassesAxiom;
-import org.semanticweb.owlapi.model.OWLEquivalentDataPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLEquivalentObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLFunctionalDataPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLHasKeyAxiom;
-import org.semanticweb.owlapi.model.OWLImportsDeclaration;
-import org.semanticweb.owlapi.model.OWLIndividual;
-import org.semanticweb.owlapi.model.OWLInverseFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLInverseObjectPropertiesAxiom;
-import org.semanticweb.owlapi.model.OWLIrreflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLLogicalAxiom;
-import org.semanticweb.owlapi.model.OWLNamedIndividual;
-import org.semanticweb.owlapi.model.OWLNegativeDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLNegativeObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLObjectPropertyDomainAxiom;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
-import org.semanticweb.owlapi.model.OWLObjectPropertyRangeAxiom;
-import org.semanticweb.owlapi.model.OWLReflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLSameIndividualAxiom;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubDataPropertyOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
-import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
-import org.semanticweb.owlapi.model.OWLSymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLTransitiveObjectPropertyAxiom;
-import org.semanticweb.owlapi.model.parameters.Navigation;
-import org.semanticweb.owlapi.util.CollectionFactory;
-import org.semanticweb.owlapi.util.OWLAxiomSearchFilter;
-import org.semanticweb.owlapi.util.OWLAxiomVisitorAdapter;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Iterables;
+import static org.semanticweb.owlapi.model.AxiomType.*;
+import static org.semanticweb.owlapi.util.CollectionFactory.createSet;
+import static org.semanticweb.owlapi.util.CollectionFactory.createSyncSet;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
+import static uk.ac.manchester.cs.owl.owlapi.InitVisitorFactory.*;
 
 /** @author ignazio */
 public class Internals implements Serializable {
@@ -319,6 +262,63 @@ public class Internals implements Serializable {
             addAxiom(ax);
         }
         axiomsForSerialization = null;
+    }
+
+    /**
+     * Trims the capacity of the axiom indexes . An application can use this operation to minimize the storage of
+     * the internals instance.
+
+     */
+
+    public void trimToSize() {
+        axiomsByType.trimToSize();
+        owlClassReferences.trimToSize();
+        owlObjectPropertyReferences.trimToSize();
+        owlDataPropertyReferences.trimToSize();
+        owlIndividualReferences.trimToSize();
+        owlAnonymousIndividualReferences.trimToSize();
+        owlDatatypeReferences.trimToSize();
+        owlAnnotationPropertyReferences.trimToSize();
+        declarationsByEntity.trimToSize();
+        classAssertionAxiomsByClass.trimToSize();
+        annotationAssertionAxiomsBySubject.trimToSize();
+        subClassAxiomsBySubPosition.trimToSize();
+        subClassAxiomsBySuperPosition.trimToSize();
+        objectSubPropertyAxiomsBySubPosition.trimToSize();
+        objectSubPropertyAxiomsBySuperPosition.trimToSize();
+        dataSubPropertyAxiomsBySubPosition.trimToSize();
+        dataSubPropertyAxiomsBySuperPosition.trimToSize();
+        classAxiomsByClass.trimToSize();
+        equivalentClassesAxiomsByClass.trimToSize();
+        disjointClassesAxiomsByClass.trimToSize();
+        disjointUnionAxiomsByClass.trimToSize();
+        hasKeyAxiomsByClass.trimToSize();
+        equivalentObjectPropertyAxiomsByProperty.trimToSize();
+        disjointObjectPropertyAxiomsByProperty.trimToSize();
+        objectPropertyDomainAxiomsByProperty.trimToSize();
+        objectPropertyRangeAxiomsByProperty.trimToSize();
+        functionalObjectPropertyAxiomsByProperty.trimToSize();
+        inverseFunctionalPropertyAxiomsByProperty.trimToSize();
+        symmetricPropertyAxiomsByProperty.trimToSize();
+        asymmetricPropertyAxiomsByProperty.trimToSize();
+        reflexivePropertyAxiomsByProperty.trimToSize();
+        irreflexivePropertyAxiomsByProperty.trimToSize();
+        transitivePropertyAxiomsByProperty.trimToSize();
+        inversePropertyAxiomsByProperty.trimToSize();
+        equivalentDataPropertyAxiomsByProperty.trimToSize();
+        disjointDataPropertyAxiomsByProperty.trimToSize();
+        dataPropertyDomainAxiomsByProperty.trimToSize();
+        dataPropertyRangeAxiomsByProperty.trimToSize();
+        functionalDataPropertyAxiomsByProperty.trimToSize();
+        classAssertionAxiomsByIndividual.trimToSize();
+        objectPropertyAssertionsByIndividual.trimToSize();
+        dataPropertyAssertionsByIndividual.trimToSize();
+        negativeObjectPropertyAssertionAxiomsByIndividual.trimToSize();
+        negativeDataPropertyAssertionAxiomsByIndividual.trimToSize();
+        differentIndividualsAxiomsByIndividual.trimToSize();
+        sameIndividualsAxiomsByIndividual.trimToSize();
+
+
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/MapPointer.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/MapPointer.java
@@ -12,28 +12,28 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package uk.ac.manchester.cs.owl.owlapi;
 
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
+import com.google.common.collect.Iterables;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.set.hash.THashSet;
-
-import java.lang.ref.SoftReference;
-import java.util.Collection;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLAxiomVisitorEx;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.util.CollectionFactory;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import uk.ac.manchester.cs.owl.owlapi.InitVisitorFactory.InitCollectionVisitor;
 import uk.ac.manchester.cs.owl.owlapi.InitVisitorFactory.InitVisitor;
 
-import com.google.common.collect.Iterables;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.lang.ref.SoftReference;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
 /**
  * * Objects that identify contained maps - so that getting the keys of a
@@ -47,6 +47,7 @@ import com.google.common.collect.Iterables;
  *        value
  */
 public class MapPointer<K, V extends OWLAxiom> {
+    private static Logger logger = LoggerFactory.getLogger(MapPointer.class);
 
     @Nullable
     private final AxiomType<?> type;
@@ -141,7 +142,6 @@ public class MapPointer<K, V extends OWLAxiom> {
         if (visitor == null) {
             return this;
         }
-        assert visitor != null;
         if (visitor instanceof InitVisitor) {
             for (V ax : (Set<V>) i.getAxiomsByType().getValues(type)) {
                 K key = ax.accept((InitVisitor<K>) visitor);
@@ -239,7 +239,7 @@ public class MapPointer<K, V extends OWLAxiom> {
     @Nonnull
     public synchronized Boolean containsKey(K key) {
         init();
-        return Boolean.valueOf(map.containsKey(key));
+        return map.containsKey(key);
     }
 
     /**
@@ -322,5 +322,18 @@ public class MapPointer<K, V extends OWLAxiom> {
             return CollectionFactory.emptySet();
         }
         return t;
+    }
+    /**
+     * Trims the capacity of the map entries . An application can use this operation to minimize the storage of the map pointer instance.
+
+     */
+
+    public void trimToSize() {
+        if (initialized) {
+            for (Map.Entry<K, THashSet<V>> entry : map.entrySet()) {
+                THashSet<V> set = entry.getValue();
+                set.trimToSize();
+            }
+        }
     }
 }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLAxiomIndexImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLAxiomIndexImpl.java
@@ -70,6 +70,14 @@ public abstract class OWLAxiomIndexImpl extends OWLObjectImpl implements
     @Nonnull
     protected final Internals ints = new Internals();
 
+    /**
+     * Trims the capacity of the axiom indexes . An application can use this operation to minimize the storage of
+     * the index instance.
+
+     */
+    public void trimToSize() {
+        ints.trimToSize();
+    }
     @Override
     public Set<OWLDeclarationAxiom> getDeclarationAxioms(OWLEntity subject) {
         return getAxioms(OWLDeclarationAxiom.class, subject, EXCLUDED,


### PR DESCRIPTION
Can save a couple of percentage points, and leaves an opening of switching the implementation of the backing sets to a packed format if the methods are called when the data structures are about to become quiescent. 
