### PR TITLE
Use a guava weak interner to reuse language tags for plain literals

### DIFF
--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImpl.java
@@ -70,6 +70,9 @@ public class OWLDataFactoryInternalsImpl extends InternalsNoCache {
     private final BuildableWeakIndexCache<OWLAnnotationProperty> annotationPropertiesByURI;
 
     @Nonnull
+    transient final private Interner<String> languageTagInterner;
+
+    @Nonnull
     protected final <V extends OWLEntity> BuildableWeakIndexCache<V>
             buildCache() {
         return new BuildableWeakIndexCache<>();
@@ -87,6 +90,7 @@ public class OWLDataFactoryInternalsImpl extends InternalsNoCache {
         datatypesByURI = buildCache();
         individualsByURI = buildCache();
         annotationPropertiesByURI = buildCache();
+        languageTagInterner = Interners.newWeakInterner();
     }
 
     @SuppressWarnings("unchecked")
@@ -194,7 +198,6 @@ public class OWLDataFactoryInternalsImpl extends InternalsNoCache {
     /*
        Use a guava weak String interner for language tags.
      */
-    private Interner<String> languageTagInterner = Interners.newWeakInterner();
 
     @Override
     public OWLLiteral getOWLLiteral(String literal, @Nullable String lang) {


### PR DESCRIPTION
This change uses a guava weak string interner to reuse language tags.

Using Opencyc.owl as test case (to switch things up a little), since almost all text literals in opencyc.owl have language tags:

Before:  total size 666,308,424 (100%), internals 502,138,144 (100%) 
After   :     total size 621,444,560 (**93%**),  internals 458,017,704 (**91%**)
