### PR TITLE
Fixed issue #330(cycle in code when rendering anonymous individual in Manchester OWL syntax)

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxObjectRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxObjectRenderer.java
@@ -310,7 +310,7 @@ public class ManchesterOWLSyntaxObjectRenderer extends AbstractRenderer
 
     @Override
     public void visit(@Nonnull OWLAnonymousIndividual individual) {
-        write(individual.toString());
+        write(individual.toStringID());
     }
 
     @Override


### PR DESCRIPTION
I just replaced the call of toString() with toStringID() such that the node ID is used according to specification http://www.w3.org/TR/owl2-manchester-syntax/ 

```
individual ::= individualIRI | nodeID
individualIRI ::= IRI
nodeID := a finite sequence of characters matching the BLANK_NODE_LABEL production of [SPARQL]
```

Not sure if the cycle occurs in some other syntax styles too. This should be checked seriously.

Creating a JUnit test seems to bit a little bit tricky because several Maven modules are needed (parsers, impl, api).
