### PR TITLE
use custom trove hash strategy

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/util/MultiMap.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/MultiMap.java
@@ -342,7 +342,7 @@ public class MultiMap<Key, Value> implements Serializable {
 
     /** @return true if all value collections are equal */
     public boolean isValueSetsEqual() {
-        if (map.size() < DEFAULT_INITIAL_CAPACITY) {
+        if (map.size() < 2) {
             return true;
         }
         List<Collection<Value>> list = new ArrayList<Collection<Value>>(

--- a/api/src/main/java/org/semanticweb/owlapi/util/MultiMap.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/MultiMap.java
@@ -38,8 +38,9 @@
  */
 package org.semanticweb.owlapi.util;
 
-import gnu.trove.map.hash.THashMap;
-import gnu.trove.set.hash.THashSet;
+import gnu.trove.map.hash.TCustomHashMap;
+import gnu.trove.set.hash.TCustomHashSet;
+import gnu.trove.strategy.HashingStrategy;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -59,7 +60,10 @@ import java.util.Set;
 public class MultiMap<Key, Value> implements Serializable {
 
     private static final long serialVersionUID = 30406L;
+    private static final int DEFAULT_INITIAL_CAPACITY = 5;
+    private static final float DEFAULT_LOAD_FACTOR = 0.75f;
     private final Map<Key, Collection<Value>> map;
+    private final HashcodeGuardedHashingStrategy<Object> keyHashcodeGuardedHashingStrategy = new HashcodeGuardedHashingStrategy<Object>();
     private int size = 0;
     private boolean useSets = true;
     private boolean threadSafe = false;
@@ -77,12 +81,12 @@ public class MultiMap<Key, Value> implements Serializable {
         threadSafe = threadsafe;
         if (threadSafe) {
             map = Collections
-                    .synchronizedMap(new THashMap<Key, Collection<Value>>(17,
-                            0.75F));
+                    .synchronizedMap(createMap());
         } else {
-            map = new THashMap<Key, Collection<Value>>(17, 0.75F);
+            map = createMap();
         }
     }
+
 
     /**
      * @param threadsafe
@@ -118,20 +122,51 @@ public class MultiMap<Key, Value> implements Serializable {
     protected Collection<Value> createCollection() {
         Collection<Value> toReturn;
         if (useSets) {
+            Set<Value> set = createSet(DEFAULT_INITIAL_CAPACITY, DEFAULT_LOAD_FACTOR);
             if (threadSafe) {
-                toReturn = Collections.synchronizedSet(new THashSet<Value>(2,
-                        0.75F));
+                toReturn = Collections.synchronizedSet(set);
             } else {
-                toReturn = new THashSet<Value>(2, 0.75F);
+                toReturn = set;
             }
         } else {
+            ArrayList<Value> list = new ArrayList<Value>();
             if (threadSafe) {
-                toReturn = Collections.synchronizedList(new ArrayList<Value>());
+                toReturn = Collections.synchronizedList(list);
             } else {
-                toReturn = new ArrayList<Value>();
+                toReturn = list;
             }
         }
         return toReturn;
+    }
+
+    private static class HashcodeGuardedHashingStrategy<Value> implements HashingStrategy<Value> {
+        @Override
+        public int computeHashCode(Value object) {
+            return object.hashCode();
+        }
+
+        @Override
+        public boolean equals(Value o1, Value o2) {
+            if (o1 == o2) {
+                return true;
+            }
+            if (o1 == null || o2 == null) {
+                return false;
+            }
+            if (computeHashCode(o1) != computeHashCode(o2)) {
+                return false;
+            }
+            return o1.equals(o2);
+        }
+    }
+
+    protected Map<Key, Collection<Value>> createMap() {
+        return new TCustomHashMap<Key, Collection<Value>>(keyHashcodeGuardedHashingStrategy,17, DEFAULT_LOAD_FACTOR);
+    }
+
+    private Set<Value> createSet(int initialCapacity, float loadFactor) {
+        return new TCustomHashSet<Value>(keyHashcodeGuardedHashingStrategy, initialCapacity, loadFactor);
+        //return new THashSet<Value>(initialCapacity, loadFactor);
     }
 
     /**
@@ -307,7 +342,7 @@ public class MultiMap<Key, Value> implements Serializable {
 
     /** @return true if all value collections are equal */
     public boolean isValueSetsEqual() {
-        if (map.size() < 2) {
+        if (map.size() < DEFAULT_INITIAL_CAPACITY) {
             return true;
         }
         List<Collection<Value>> list = new ArrayList<Collection<Value>>(
@@ -319,4 +354,5 @@ public class MultiMap<Key, Value> implements Serializable {
         }
         return true;
     }
+
 }

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
@@ -1,10 +1,5 @@
 package org.obolibrary.obo2owl;
 
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Set;
-
 import org.coode.owlapi.functionalparser.OWLFunctionalSyntaxOWLParser;
 import org.coode.owlapi.functionalrenderer.OWLFunctionalSyntaxRenderer;
 import org.semanticweb.owlapi.io.OWLOntologyDocumentSource;
@@ -17,6 +12,11 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.UnloadableImportException;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Set;
 
 /**
  * Tools to read and write a set of owl axioms to/from a string. Used to
@@ -53,7 +53,7 @@ public class OwlStringTools {
      * @return string or null
      * @throws OwlStringException
      *         OwlStringException
-     * @see #translate(String, OWLOntologyManager)
+     * @see #translate(String, OWLOntologyManager,org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration)
      */
     
     public static String translate( Set<OWLAxiom> axioms,

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
@@ -1,5 +1,10 @@
 package org.obolibrary.obo2owl;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Set;
+
 import org.coode.owlapi.functionalparser.OWLFunctionalSyntaxOWLParser;
 import org.coode.owlapi.functionalrenderer.OWLFunctionalSyntaxRenderer;
 import org.semanticweb.owlapi.io.OWLOntologyDocumentSource;
@@ -12,11 +17,6 @@ import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.UnloadableImportException;
-
-import java.io.IOException;
-import java.io.StringWriter;
-import java.io.Writer;
-import java.util.Set;
 
 /**
  * Tools to read and write a set of owl axioms to/from a string. Used to
@@ -53,12 +53,11 @@ public class OwlStringTools {
      * @return string or null
      * @throws OwlStringException
      *         OwlStringException
-     * @see #translate(String, OWLOntologyManager,org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration)
+     * @see #translate(String,
+     *      OWLOntologyManager,org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration)
      */
-    
-    public static String translate( Set<OWLAxiom> axioms,
-             OWLOntologyManager translationManager)
-            throws OwlStringException {
+    public static String translate(Set<OWLAxiom> axioms,
+            OWLOntologyManager translationManager) throws OwlStringException {
         if (axioms == null || axioms.isEmpty()) {
             return null;
         }
@@ -84,14 +83,15 @@ public class OwlStringTools {
      *        axioms
      * @param translationManager
      *        translationManager
+     * @param config
+     *        the loader configuration, passed to the parser
      * @return set of axioms or null
      * @throws OwlStringException
      *         OwlStringException
      * @see #translate(Set,OWLOntologyManager)
      */
-    
-    public static Set<OWLAxiom> translate( String axioms,
-             OWLOntologyManager translationManager,
+    public static Set<OWLAxiom> translate(String axioms,
+            OWLOntologyManager translationManager,
             OWLOntologyLoaderConfiguration config) throws OwlStringException {
         if (axioms == null || axioms.isEmpty()) {
             return null;


### PR DESCRIPTION
Use a custom trove hashing strategy in multimap.  

This strategy uses == as a shortcut for true, and hashCode != hashCode as a shortcut for false.  This avoid having to avoids having to make changes to all the axiom implementations to get a win.

(There are also a few stray reformatting related oopses from the obo javadoc fix and an accidental sufficiently large value of 2)