### PR TITLE
Change scope of owlapi internal dependencies in osgidistribution to use scope 'provided'

### DIFF
--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -19,31 +19,37 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-apibinding</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-api</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-tools</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-impl</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-parsers</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-oboformat</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 
@@ -73,7 +79,7 @@
 						javax.xml.*, org.xml.sax.*
 						</Import-Package>
 					</instructions>
-					<executions>
+				<!--	<executions>
 						<execution>
 							<id>bundle-manifest</id>
 							<phase>install</phase>
@@ -81,7 +87,7 @@
 								<goal>manifest</goal>
 							</goals>
 						</execution>
-					</executions>
+					</executions>  -->
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Change scope of owlapi internal dependencies in osgidistribution to be provided;  this makes them not be transitive. 
 Since the contents of these jars are shaded into the bundle, jar, having extra dependencies in the pom is not useful.