### PR TITLE
Version3  -error tolerant inferred ontology generation

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/util/InferredOntologyGenerator.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/InferredOntologyGenerator.java
@@ -40,6 +40,7 @@ package org.semanticweb.owlapi.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.semanticweb.owlapi.model.AddAxiom;
 import org.semanticweb.owlapi.model.OWLAxiom;
@@ -151,7 +152,8 @@ public class InferredOntologyGenerator {
                     changes.add(new AddAxiom(ontology, ax));
                 }
             } catch (Exception e) {
-                logger.warning("Error generating axioms for " + axiomGenerator.getLabel() +": " +  e); //To change body of catch statement use File | Settings | File Templates.
+                logger.log(Level.WARNING,
+                        "Error generating " + axiomGenerator.getLabel() + "axioms using  " + reasoner.getReasonerName() + ", version " + reasoner.getReasonerVersion(), e); //To change body of catch statement use File | Settings | File Templates.
             }
         }
         manager.applyChanges(changes);

--- a/api/src/main/java/org/semanticweb/owlapi/util/InferredOntologyGenerator.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/InferredOntologyGenerator.java
@@ -40,7 +40,7 @@ package org.semanticweb.owlapi.util;
 
 import java.util.ArrayList;
 import java.util.List;
-
+import java.util.logging.Logger;
 import org.semanticweb.owlapi.model.AddAxiom;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
@@ -59,7 +59,7 @@ import org.semanticweb.owlapi.reasoner.OWLReasoner;
  *         Informatics Group, Date: 27-Jul-2007
  */
 public class InferredOntologyGenerator {
-
+    private static Logger logger =   Logger.getLogger(InferredOntologyGenerator.class.getName());
     // The reasoner which is used to compute the inferred axioms
     private final OWLReasoner reasoner;
     private final List<InferredAxiomGenerator<? extends OWLAxiom>> axiomGenerators;
@@ -146,8 +146,12 @@ public class InferredOntologyGenerator {
             throws OWLOntologyChangeException {
         List<OWLOntologyChange> changes = new ArrayList<OWLOntologyChange>();
         for (InferredAxiomGenerator<? extends OWLAxiom> axiomGenerator : axiomGenerators) {
-            for (OWLAxiom ax : axiomGenerator.createAxioms(manager, reasoner)) {
-                changes.add(new AddAxiom(ontology, ax));
+            try {
+                for (OWLAxiom ax : axiomGenerator.createAxioms(manager, reasoner)) {
+                    changes.add(new AddAxiom(ontology, ax));
+                }
+            } catch (Exception e) {
+                logger.warning("Error generating axioms for " + axiomGenerator.getLabel() +": " +  e); //To change body of catch statement use File | Settings | File Templates.
             }
         }
         manager.applyChanges(changes);


### PR DESCRIPTION
This change catches Exceptions that may be thrown by an inferred axiom generator when generating an inferred ontology.  

Each generator only gets to throw one exception, since the purpose is to allow IOG to be usedwith reasoners that do not support certain type of inference, and which also do not support OWLReasoner::isEntailed, and hence may return false for all calls to OWLReasoner::isEntailmentCheckingSupported.

 This kludge lets ELK work with protege's classification result view.