### PR TITLE
Add legacy files  to the OSGI distribution for  version 3.5 backwards compatibility

### DIFF
--- a/osgidistribution/src/main/java/org/coode/owlapi/obo/renderer/OBOFlatFileOntologyStorer.java
+++ b/osgidistribution/src/main/java/org/coode/owlapi/obo/renderer/OBOFlatFileOntologyStorer.java
@@ -1,0 +1,14 @@
+package org.coode.owlapi.obo.renderer;/**
+ * Created by ses on 2/16/15.
+ */
+
+import org.semanticweb.owlapi.oboformat.OBOFormatStorer;
+
+/**
+ * Legacy class name to support protege dependencies
+ */
+@Deprecated
+public class OBOFlatFileOntologyStorer extends OBOFormatStorer {
+
+
+}

--- a/osgidistribution/src/main/java/uk/ac/manchester/cs/owl/explanation/ordering/DefaultExplanationOrderer.java
+++ b/osgidistribution/src/main/java/uk/ac/manchester/cs/owl/explanation/ordering/DefaultExplanationOrderer.java
@@ -1,0 +1,100 @@
+/*
+ * This file is part of the OWL API.
+ *
+ * The contents of this file are subject to the LGPL License, Version 3.0.
+ *
+ * Copyright (C) 2011, The University of Manchester
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of the Apache License, Version 2.0
+ * in which case, the provisions of the Apache License Version 2.0 are applicable instead of those above.
+ *
+ * Copyright 2011, The University of Manchester
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.ac.manchester.cs.owl.explanation.ordering;
+
+import java.util.Set;
+
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLObject;
+import org.semanticweb.owlapi.model.OWLOntologyIRIMapper;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+
+/**
+ * Legacy class to support protege dependencies  Protege
+ * Provides ordering and indenting of explanations based on various ordering
+ * heuristics.
+ * 
+ * @author Matthew Horridge, The University Of Manchester, Bio-Health
+ *         Informatics Group, Date: 11-Jan-2008
+ * @deprecated use ExplanationOrdererImpl instead - this class depends on
+ *             OWLManager, while ExplanationOrdererImpl does not.
+ */
+@Deprecated
+public class DefaultExplanationOrderer implements ExplanationOrderer {
+
+    private ExplanationOrdererImpl delegate;
+
+    @SuppressWarnings("javadoc")
+    public DefaultExplanationOrderer() {
+        OWLOntologyManager man = OWLManager.createOWLOntologyManager();
+        man.addIRIMapper(new OWLOntologyIRIMapper() {
+
+            @Override
+            public IRI getDocumentIRI(IRI ontologyIRI) {
+                return ontologyIRI;
+            }
+        });
+        delegate = new ExplanationOrdererImpl(man);
+    }
+
+    @Override
+    public ExplanationTree getOrderedExplanation(OWLAxiom entailment,
+            Set<OWLAxiom> axioms) {
+        return delegate.getOrderedExplanation(entailment, axioms);
+    }
+
+    /**
+     * Gets axioms that have a LHS corresponding to the specified entity.
+     * 
+     * @param lhs
+     *        The entity that occurs on the left hand side of the axiom.
+     * @return A set of axioms that have the specified entity as their left hand
+     *         side.
+     */
+    protected Set<OWLAxiom> getAxiomsForLHS(OWLEntity lhs) {
+        return delegate.getAxiomsForLHS(lhs);
+    }
+
+    protected void indexAxiomsByRHSEntities(OWLObject rhs, OWLAxiom axiom) {
+        delegate.indexAxiomsByRHSEntities(rhs, axiom);
+    }
+}


### PR DESCRIPTION
Add  classes org.coode.owlapi.obo.renderer.OBOFlatFileOntologyStorer and  uk.ac.manchester.cs.owl.explanation.ordering.DefaultExplanationOrderer to satisfy legacy Protegé dependencies. 

The stub source is in osgidistribution (to avoid a cyclic dependency on owlapibinding). 

This is not a good location for real code.

Fortunately this is not real code.
