### PR TITLE
Simplify trivially transitive check

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/util/InferredObjectPropertyCharacteristicAxiomGenerator.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/InferredObjectPropertyCharacteristicAxiomGenerator.java
@@ -12,18 +12,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi.util;
 
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
-import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyCharacteristicAxiom;
+import org.semanticweb.owlapi.model.OWLObjectSomeValuesFrom;
 import org.semanticweb.owlapi.reasoner.OWLReasoner;
 
 /**
@@ -86,18 +82,11 @@ public class InferredObjectPropertyCharacteristicAxiomGenerator
     private static boolean triviallyTransitiveCheck(
             @Nonnull OWLObjectProperty property, OWLReasoner reasoner,
             OWLDataFactory df) {
-        if (!reasoner
-                .isEntailmentCheckingSupported(AxiomType.OBJECT_PROPERTY_ASSERTION)) {
-            return true;
-        }
-        OWLAnonymousIndividual a = df.getOWLAnonymousIndividual();
-        OWLAnonymousIndividual b = df.getOWLAnonymousIndividual();
-        OWLAnonymousIndividual c = df.getOWLAnonymousIndividual();
-        Set<OWLAxiom> trivialityCheckAxioms = new HashSet<>(
-                Arrays.<OWLAxiom> asList(
-                        df.getOWLObjectPropertyAssertionAxiom(property, a, b),
-                        df.getOWLObjectPropertyAssertionAxiom(property, b, c)));
-        return !reasoner.isEntailed(trivialityCheckAxioms);
+		// create R some (R some owl:Thing) class
+		OWLObjectSomeValuesFrom chain = df.getOWLObjectSomeValuesFrom(property,
+				df.getOWLObjectSomeValuesFrom(property, df.getOWLThing()));
+		// if chain is unsatisfiable, then the property is trivially transitive
+		return !reasoner.isSatisfiable(chain);
     }
 
     protected static void addIfEntailed(


### PR DESCRIPTION
Property is trivially transitive if it can not participate in chains of length more than 1, i.e. s0 -R-> s1 -R-> s2 is inconsistent for (anonymous) s0, s1, s2. This check is used in class InferredObjectPropertyCharacteristicAxiomGenerator to mark trivially transitive property as non-transitive. While questionable on its own (the property **is** transitive in the end), the implementation is really complicated, and involve checking entailment of a set of 2 axioms with anonymous individuals. The proposed implementation is much simpler and gives the same results in almost all cases (the results will only differ on the models with domains of size 1 or 2, which is rather artificial situation). It should also work with any reasoner that allows satisfiability checking.