### PR TITLE
Add Implementation Version to the generated bundle manifest

### DIFF
--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -63,6 +63,7 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
+						<Implementation-Version>${project.version}</Implementation-Version>
 						<Bundle-SymbolicName>org.semanticweb.owl.owlapi</Bundle-SymbolicName>
 						<Embed-Dependency>guava, trove4j</Embed-Dependency>
 						<Export-Package>


### PR DESCRIPTION
Makes the ${project.version} available to the  Version class automagically