### PR TITLE
Support separation of unit and integration tests using junit categories.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+script: "mvn verify"
 jdk:
   - openjdk7
   - oraclejdk7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+cache:
+  directories:
+    - $HOME/.m2
+
 language: java
 script: "mvn verify"
 jdk:

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/VerifyVersionInfoTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/VerifyVersionInfoTestCase.java
@@ -1,5 +1,6 @@
 package org.semanticweb.owlapi.api.test;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -7,6 +8,8 @@ import java.io.File;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.semanticweb.owlapi.test.IntegrationTest;
 import org.semanticweb.owlapi.util.VersionInfo;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -14,6 +17,7 @@ import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
 
 @SuppressWarnings("javadoc")
+@Category(IntegrationTest.class)
 public class VerifyVersionInfoTestCase {
 
     @Test
@@ -29,11 +33,11 @@ public class VerifyVersionInfoTestCase {
             if (n instanceof Element
                     && ((Element) n).getTagName().equals("version")) {
                 String version = ((Element) n).getTextContent();
-                if (!version.equals(info.getVersion())) {
+                /*if (!version.equals(info.getVersion())) {
                     System.out
                             .println("VerifyVersionInfo.checkMatchVersion() WARNING: update the version in VersionInfo");
-                }
-                // assertEquals(version, info.getVersion());
+                }*/
+                assertEquals(version, info.getVersion());
                 found = true;
             }
         }
@@ -49,11 +53,13 @@ public class VerifyVersionInfoTestCase {
                     if (n instanceof Element
                             && ((Element) n).getTagName().equals("version")) {
                         String version = ((Element) n).getTextContent();
+/*
                         if (!version.equals(info.getVersion())) {
                             System.out
                                     .println("VerifyVersionInfo.checkMatchVersion() WARNING: update the version in VersionInfo");
                         }
-                        // assertEquals(version, info.getVersion());
+*/
+                        assertEquals(version, info.getVersion());
                         found = true;
                     }
                 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/AnnotatedPunningTest.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/AnnotatedPunningTest.java
@@ -1,131 +1,13 @@
 package org.semanticweb.owlapi.api.test.annotations;
 
-import static org.junit.Assert.assertEquals;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-
-import org.coode.owlapi.manchesterowlsyntax.ManchesterOWLSyntaxOntologyFormat;
-import org.coode.owlapi.turtle.TurtleOntologyFormat;
-import org.junit.Before;
-import org.junit.Test;
-import org.semanticweb.owlapi.apibinding.OWLManager;
-import org.semanticweb.owlapi.io.OWLFunctionalSyntaxOntologyFormat;
-import org.semanticweb.owlapi.io.RDFXMLOntologyFormat;
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyCreationException;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
-import org.semanticweb.owlapi.model.OWLOntologyStorageException;
-import org.semanticweb.owlapi.util.DefaultPrefixManager;
-import org.semanticweb.owlapi.vocab.PrefixOWLOntologyFormat;
+import org.junit.runner.RunWith;
 
 /**
  * Created by ses on 5/13/14.
  */
 @SuppressWarnings("javadoc")
+@RunWith(PunRunner.class)
 public class AnnotatedPunningTest {
 
-    private OWLOntologyManager m;
-    private OWLDataFactory df;
 
-    @Before
-    public void setUp() {
-        m = OWLManager.createOWLOntologyManager();
-        df = m.getOWLDataFactory();
-    }
-
-    @Test
-    public void testAllTwoWayPuns() throws Exception {
-        DefaultPrefixManager pm = new DefaultPrefixManager("http://localhost#");
-        List<? extends OWLEntity> entities = Arrays.asList(
-                df.getOWLClass("a", pm), df.getOWLDatatype("a", pm),
-                df.getOWLAnnotationProperty("a", pm),
-                df.getOWLDataProperty("a", pm),
-                df.getOWLObjectProperty("a", pm),
-                df.getOWLNamedIndividual("a", pm));
-        OWLAnnotationProperty annotationProperty = df.getOWLAnnotationProperty(
-                ":ap", pm);
-        for (OWLEntity e1 : entities) {
-            for (OWLEntity e2 : entities) {
-                testFormats(annotationProperty, e1, e2);
-            }
-        }
-    }
-
-    @Test
-    public void testMultiPun() throws Exception {
-        DefaultPrefixManager pm = new DefaultPrefixManager("http://localhost#");
-        OWLAnnotationProperty annotationProperty = df.getOWLAnnotationProperty(
-                ":ap", pm);
-        testFormats(annotationProperty, df.getOWLClass("a", pm),
-                df.getOWLDatatype("a", pm),
-                df.getOWLAnnotationProperty("a", pm),
-                df.getOWLDataProperty("a", pm),
-                df.getOWLObjectProperty("a", pm),
-                df.getOWLNamedIndividual("a", pm));
-    }
-
-    public void testFormats(OWLAnnotationProperty annotationProperty,
-            OWLEntity... entities) throws OWLOntologyCreationException,
-            OWLOntologyStorageException, IllegalAccessException,
-            InstantiationException {
-        runTestForAnnotationsOnPunnedEntitiesForFormat(
-                RDFXMLOntologyFormat.class, annotationProperty, entities);
-        runTestForAnnotationsOnPunnedEntitiesForFormat(
-                TurtleOntologyFormat.class, annotationProperty, entities);
-        runTestForAnnotationsOnPunnedEntitiesForFormat(
-                OWLFunctionalSyntaxOntologyFormat.class, annotationProperty,
-                entities);
-        runTestForAnnotationsOnPunnedEntitiesForFormat(
-                ManchesterOWLSyntaxOntologyFormat.class, annotationProperty,
-                entities);
-    }
-
-    public void runTestForAnnotationsOnPunnedEntitiesForFormat(
-            Class<? extends PrefixOWLOntologyFormat> formatClass,
-            OWLAnnotationProperty annotationProperty, OWLEntity... entities)
-            throws OWLOntologyCreationException, OWLOntologyStorageException,
-            IllegalAccessException, InstantiationException {
-        OWLOntology o = makeOwlOntologyWithDeclarationsAndAnnotationAssertions(
-                annotationProperty, entities);
-        for (int i = 0; i < 10; i++) {
-            PrefixOWLOntologyFormat format = formatClass.newInstance();
-            format.setPrefixManager(new DefaultPrefixManager(
-                    "http://localhost#"));
-            ByteArrayInputStream in = saveForRereading(o, format);
-            m.removeOntology(o);
-            o = m.loadOntologyFromOntologyDocument(in);
-        }
-        assertEquals("annotationCount", entities.length,
-                o.getAxioms(AxiomType.ANNOTATION_ASSERTION).size());
-    }
-
-    public OWLOntology makeOwlOntologyWithDeclarationsAndAnnotationAssertions(
-            OWLAnnotationProperty annotationProperty, OWLEntity... entities)
-            throws OWLOntologyCreationException {
-        Set<OWLAxiom> axioms = new HashSet<OWLAxiom>();
-        axioms.add(df.getOWLDeclarationAxiom(annotationProperty));
-        for (OWLEntity entity : entities) {
-            axioms.add(df.getOWLAnnotationAssertionAxiom(annotationProperty,
-                    entity.getIRI(), df.getOWLAnonymousIndividual()));
-            axioms.add(df.getOWLDeclarationAxiom(entity));
-        }
-        return m.createOntology(axioms);
-    }
-
-    public ByteArrayInputStream saveForRereading(OWLOntology o,
-            PrefixOWLOntologyFormat format) throws OWLOntologyStorageException {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        m.saveOntology(o, format, out);
-        return new ByteArrayInputStream(out.toByteArray());
-    }
 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/PunRunner.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/PunRunner.java
@@ -1,0 +1,181 @@
+package org.semanticweb.owlapi.api.test.annotations;/**
+ * Created by ses on 3/2/15.
+ */
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.coode.owlapi.manchesterowlsyntax.ManchesterOWLSyntaxOntologyFormat;
+import org.coode.owlapi.turtle.TurtleOntologyFormat;
+import static org.junit.Assert.assertEquals;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.semanticweb.owlapi.apibinding.OWLManager;
+import org.semanticweb.owlapi.io.OWLFunctionalSyntaxOntologyFormat;
+import org.semanticweb.owlapi.io.RDFXMLOntologyFormat;
+import org.semanticweb.owlapi.model.AxiomType;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLEntity;
+import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyCreationException;
+import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.OWLOntologyStorageException;
+import org.semanticweb.owlapi.util.DefaultPrefixManager;
+import org.semanticweb.owlapi.vocab.PrefixOWLOntologyFormat;
+
+public class PunRunner extends org.junit.runner.Runner {
+    private final Class testClass;
+
+    public PunRunner(Class testClass) {
+        this.testClass = testClass;
+        System.err.println("PunRunner started");
+    }
+
+    class TestSetting {
+        OWLEntity[] entities;
+        Class<? extends PrefixOWLOntologyFormat> formatClass;
+
+        public TestSetting(Class<? extends PrefixOWLOntologyFormat> formatClass, OWLEntity... entities) {
+            this.formatClass = formatClass;
+            this.entities = entities;
+        }
+    }
+
+    private Description suiteDescription;
+    private Map<Description, TestSetting> testSettings = new HashMap<Description, TestSetting>();
+
+    @Override
+    public Description getDescription() {
+        suiteDescription = Description.createSuiteDescription(testClass);
+        addAllTests();
+        return suiteDescription;
+    }
+
+    private void addAllTests() {
+        DefaultPrefixManager pm = new DefaultPrefixManager("http://localhost#");
+        OWLDataFactory df = OWLManager.getOWLDataFactory();
+        List<? extends OWLEntity> entities = Arrays.asList(
+                df.getOWLClass("a", pm), df.getOWLDatatype("a", pm),
+                df.getOWLAnnotationProperty("a", pm),
+                df.getOWLDataProperty("a", pm),
+                df.getOWLObjectProperty("a", pm),
+                df.getOWLNamedIndividual("a", pm));
+        List<Class<? extends PrefixOWLOntologyFormat>> formats = Arrays.asList(
+                RDFXMLOntologyFormat.class,
+                TurtleOntologyFormat.class,
+                OWLFunctionalSyntaxOntologyFormat.class,
+                ManchesterOWLSyntaxOntologyFormat.class
+        );
+        for (Class<? extends PrefixOWLOntologyFormat> formatClass : formats) {
+            for (int i = 0; i < entities.size(); i++) {
+                OWLEntity e1 = entities.get(i);
+                for (int j = i + 1; j < entities.size(); j++) {
+                    OWLEntity e2 = entities.get(j);
+                    String formatClassName = formatClass.getName();
+                    int i1 = formatClassName.lastIndexOf('.');
+                    if (i1 > -1) {
+                        formatClassName = formatClassName.substring(i1 + 1);
+                    }
+                    String name = String.format("%sVs%sFor%s", e1.getEntityType(), e2.getEntityType(), formatClassName);
+                    Description testDescription = Description.createTestDescription(testClass, name);
+                    testSettings.put(testDescription, new TestSetting(formatClass, e1, e2));
+                    suiteDescription.addChild(testDescription);
+                }
+            }
+            String name = "multiPun for " + formatClass.getName();
+            Description testDescription = Description.createTestDescription(testClass, name);
+            suiteDescription.addChild(testDescription);
+            TestSetting setting =
+                    new TestSetting(formatClass,
+                            df.getOWLClass("a", pm),
+                            df.getOWLDatatype("a", pm),
+                            df.getOWLAnnotationProperty("a", pm),
+                            df.getOWLDataProperty("a", pm),
+                            df.getOWLObjectProperty("a", pm),
+                            df.getOWLNamedIndividual("a", pm));
+            testSettings.put(testDescription, setting);
+        }
+    }
+
+    /**
+     * Run the tests for this runner.
+     *
+     * @param notifier will be notified of events while tests are being run--tests being
+     *                 started, finishing, and failing
+     */
+    @Override
+    public void run(RunNotifier notifier) {
+        for (Map.Entry<Description, TestSetting> entry : testSettings.entrySet()) {
+            Description description = entry.getKey();
+            notifier.fireTestStarted(description);
+            try {
+                TestSetting setting = entry.getValue();
+                runTestForAnnotationsOnPunnedEntitiesForFormat(setting.formatClass, setting.entities);
+            } catch (Throwable t) {
+                notifier.fireTestFailure(new Failure(description, t));
+            } finally {
+                notifier.fireTestFinished(description);
+            }
+        }
+    }
+
+    public void runTestForAnnotationsOnPunnedEntitiesForFormat(
+            Class<? extends PrefixOWLOntologyFormat> formatClass, OWLEntity... entities)
+            throws OWLOntologyCreationException, OWLOntologyStorageException,
+            IllegalAccessException, InstantiationException {
+
+        OWLOntologyManager ontologyManager;
+        OWLDataFactory df;
+        synchronized (OWLManager.class) {
+            ontologyManager = OWLManager.createOWLOntologyManager();
+            df = ontologyManager.getOWLDataFactory();
+        }
+
+        OWLAnnotationProperty annotationProperty = df.getOWLAnnotationProperty(
+                ":ap", new DefaultPrefixManager(
+                        "http://localhost#"));
+
+        OWLOntology o = makeOwlOntologyWithDeclarationsAndAnnotationAssertions(
+                annotationProperty, ontologyManager, entities);
+        for (int i = 0; i < 10; i++) {
+            PrefixOWLOntologyFormat format = formatClass.newInstance();
+            format.setPrefixManager(new DefaultPrefixManager(
+                    "http://localhost#"));
+            ByteArrayInputStream in = saveForRereading(o, format, ontologyManager);
+            ontologyManager.removeOntology(o);
+            o = ontologyManager.loadOntologyFromOntologyDocument(in);
+        }
+        assertEquals("annotationCount", entities.length,
+                o.getAxioms(AxiomType.ANNOTATION_ASSERTION).size());
+    }
+
+    public static OWLOntology makeOwlOntologyWithDeclarationsAndAnnotationAssertions(
+            OWLAnnotationProperty annotationProperty, OWLOntologyManager manager, OWLEntity... entities)
+            throws OWLOntologyCreationException {
+        Set<OWLAxiom> axioms = new HashSet<OWLAxiom>();
+        OWLDataFactory dataFactory = manager.getOWLDataFactory();
+        axioms.add(dataFactory.getOWLDeclarationAxiom(annotationProperty));
+        for (OWLEntity entity : entities) {
+            axioms.add(dataFactory.getOWLAnnotationAssertionAxiom(annotationProperty,
+                    entity.getIRI(), dataFactory.getOWLAnonymousIndividual()));
+            axioms.add(dataFactory.getOWLDeclarationAxiom(entity));
+        }
+        return manager.createOntology(axioms);
+    }
+
+    public static ByteArrayInputStream saveForRereading(OWLOntology o,
+                                                        PrefixOWLOntologyFormat format, OWLOntologyManager manager) throws OWLOntologyStorageException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        manager.saveOntology(o, format, out);
+        return new ByteArrayInputStream(out.toByteArray());
+    }
+
+}

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -74,11 +74,11 @@
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>
-						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
 						<configuration>
+							<skip>${no-javadoc}</skip>
 							<includeDependencySources>true</includeDependencySources>
 							<dependencySourceIncludes>
 								<dependencySourceInclude>net.sourceforge.owlapi:owlapi-api</dependencySourceInclude>
@@ -105,7 +105,6 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>install</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,15 +66,6 @@
 							org.obolibrary.*
 						</Export-Package>
 					</instructions>
-					<executions>
-						<execution>
-							<id>bundle-manifest</id>
-							<phase>install</phase>
-							<goals>
-								<goal>manifest</goal>
-							</goals>
-						</execution>
-					</executions>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -83,6 +74,7 @@
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>
+						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
@@ -113,7 +105,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>package</phase>
+						<phase>install</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>

--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -96,6 +96,7 @@
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>
+						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
@@ -126,7 +127,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>package</phase>
+						<phase>install</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>

--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -96,11 +96,11 @@
 				<executions>
 					<execution>
 						<id>attach-javadoc</id>
-						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
 						<configuration>
+							<skip>${no-javadoc}</skip>
 							<includeDependencySources>true</includeDependencySources>
 							<dependencySourceIncludes>
 								<dependencySourceInclude>net.sourceforge.owlapi:owlapi-api</dependencySourceInclude>
@@ -127,7 +127,6 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>install</phase>
 						<goals>
 							<goal>single</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -163,6 +163,36 @@
 							</instructions>
 						</configuration>
 					</plugin>
+					<!-- We need to configure the Source Plugin for deploying the sources. -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-source-plugin</artifactId>
+						<version>2.2.1</version>
+						<executions>
+							<execution>
+								<id>attach-sources</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
+					<!-- We need to configure the Javadoc Plugin for deploying the Javadocs -->
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<version>2.8.1</version>
+						<executions>
+							<execution>
+								<id>attach-javadocs</id>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+							</execution>
+						</executions>
+					</plugin>
+
 				</plugins>
 			</build>
 		</profile>
@@ -191,6 +221,7 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
+						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
@@ -206,6 +237,7 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
+						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>

--- a/pom.xml
+++ b/pom.xml
@@ -183,6 +183,9 @@
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<version>2.8.1</version>
+						<configuration>
+							<skip>false</skip>
+						</configuration>
 						<executions>
 							<execution>
 								<id>attach-javadocs</id>
@@ -221,7 +224,6 @@
 				<executions>
 					<execution>
 						<id>attach-sources</id>
-						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
@@ -237,10 +239,12 @@
 				<executions>
 					<execution>
 						<id>attach-javadocs</id>
-						<phase>install</phase>
 						<goals>
 							<goal>jar</goal>
 						</goals>
+						<configuration>
+						 	<skip>${no-javadoc}</skip>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
@@ -323,6 +327,7 @@
 	<!-- Specify the encoding of the source files. -->
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<no-javadoc>true</no-javadoc>
 	</properties>
 
 	<!-- Parameters for the Source Code Management system. -->

--- a/pom.xml
+++ b/pom.xml
@@ -254,9 +254,12 @@
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.18.1</version>
 				<configuration>
-						<excludedGroups>org.semanticweb.owlapi.test.IntegrationTest</excludedGroups>
+					<excludedGroups>org.semanticweb.owlapi.test.IntegrationTest</excludedGroups>
 					<printSummary>false</printSummary>
-					<argLine>-Xmx1024M -Djava.awt.headless=true</argLine>
+					<parallel>all</parallel>
+					<threadCount>1</threadCount>
+					<perCoreThreadCount>true</perCoreThreadCount>
+					<argLine>-Xmx2G -Djava.awt.headless=true</argLine>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
 	<url>http://owlapi.sourceforge.net/</url>
 
 	<modules>
+		<module>testsupport</module>
 		<module>api</module>
 		<module>impl</module>
 		<module>tools</module>
@@ -72,13 +73,19 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>
 			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>${project.groupId}</groupId>
+			<artifactId>owlapi-testsupport</artifactId>
+			<version>${project.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -149,6 +156,7 @@
 						<extensions>true</extensions>
 						<configuration>
 							<instructions>
+								<Implementation-Version>${project.version}</Implementation-Version>
 								<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 								<Bundle-Name>${project.artifactId}</Bundle-Name>
 								<Export-Package>{local-packages}</Export-Package>
@@ -208,11 +216,30 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.17</version>
+				<version>2.18.1</version>
 				<configuration>
+						<excludedGroups>org.semanticweb.owlapi.test.IntegrationTest</excludedGroups>
 					<printSummary>false</printSummary>
 					<argLine>-Xmx1024M -Djava.awt.headless=true</argLine>
 				</configuration>
+			</plugin>
+			<plugin>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>2.18.1</version>
+				<configuration>
+					<includes>
+						<include>**/*.java</include>
+					</includes>
+					<groups>org.semanticweb.owlapi.test.IntegrationTest</groups>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>org.sonatype.plugins</groupId>
@@ -225,6 +252,21 @@
 					<autoReleaseAfterClose>true</autoReleaseAfterClose>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.felix</groupId>
+				<artifactId>maven-bundle-plugin</artifactId>
+				<version>2.3.7</version>
+				<extensions>true</extensions>
+				<configuration>
+					<instructions>
+						<Implementation-Version>${project.version}</Implementation-Version>
+						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+						<Bundle-Name>${project.artifactId}</Bundle-Name>
+						<Export-Package>{local-packages}</Export-Package>
+					</instructions>
+				</configuration>
+			</plugin>
+
 			<!-- the FindBugs plugin for extra checks -->
 			<!--plugin>
 				<groupId>org.codehaus.mojo</groupId>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <groupId>net.sourceforge.owlapi</groupId>
+    <version>3.5.2-SNAPSHOT</version>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>owlapi-testsupport</artifactId>
+
+</project>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -2,9 +2,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
     <groupId>net.sourceforge.owlapi</groupId>
     <version>3.5.2-SNAPSHOT</version>
-    <modelVersion>4.0.0</modelVersion>
     <artifactId>owlapi-testsupport</artifactId>
     <build>
         <plugins>

--- a/testsupport/pom.xml
+++ b/testsupport/pom.xml
@@ -6,5 +6,94 @@
     <version>3.5.2-SNAPSHOT</version>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>owlapi-testsupport</artifactId>
+    <build>
+        <plugins>
+            <!-- In the Compiler Plugin we specify the encoding and the compiler version. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                    <encoding>UTF-8</encoding>
+                </configuration>
+            </plugin>
 
+            <!-- We need to configure the Source Plugin for deploying the sources. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>2.2.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- We need to configure the Javadoc Plugin for deploying the Javadocs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>2.8.1</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>install</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <includes>
+                        <include>**/*.java</include>
+                    </includes>
+                    <groups>org.semanticweb.owlapi.test.IntegrationTest</groups>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.2</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Implementation-Version>${project.version}</Implementation-Version>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>{local-packages}</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/testsupport/src/main/java/org/semanticweb/owlapi/test/IntegrationTest.java
+++ b/testsupport/src/main/java/org/semanticweb/owlapi/test/IntegrationTest.java
@@ -1,0 +1,5 @@
+package org.semanticweb.owlapi.test;
+
+
+public interface IntegrationTest {
+}


### PR DESCRIPTION
This change set 
1. Adds a new project, owlapi-testsupport, to hold the required marker interface.   This project does not have owlapi-parent as parent.
2. Adds owlapi-testsupport as a test dependency in owlapi-parent.
3. Excludes the category from surefire config in owlapi-parent.
4. Includes the category in failsafe config in owlapi-parent. 

The change set also makes VerifyVersionInfoTestCase an integration test, and sets Implementation-Version in the bundle instructions so that it passes.  