### PR TITLE
Solve some thread safety issues in XML parsers and storers

### DIFF
--- a/parsers/src/main/java/org/coode/xml/XMLWriterImpl.java
+++ b/parsers/src/main/java/org/coode/xml/XMLWriterImpl.java
@@ -64,6 +64,7 @@ import org.semanticweb.owlapi.vocab.OWL2Datatype;
  */
 public class XMLWriterImpl implements XMLWriter {
 
+    private final XMLWriterPreferences instance = XMLWriterPreferences.getInstance();
     private Stack<XMLElement> elementStack;
     protected Writer writer;
     private String encoding = "";
@@ -305,7 +306,7 @@ public class XMLWriterImpl implements XMLWriter {
             encodingString = " encoding=\"" + encoding + "\"";
         }
         writer.write("<?xml version=\"1.0\"" + encodingString + "?>\n");
-        if (XMLWriterPreferences.getInstance().isUseNamespaceEntities()) {
+        if (instance.isUseNamespaceEntities()) {
             writeEntities(rootElement);
         }
         preambleWritten = true;
@@ -494,7 +495,7 @@ public class XMLWriterImpl implements XMLWriter {
             writer.write(attr);
             writer.write('=');
             writer.write('"');
-            if (XMLWriterPreferences.getInstance().isUseNamespaceEntities()) {
+            if (instance.isUseNamespaceEntities()) {
                 writer.write(swapForEntity(XMLUtils.escapeXML(val)));
             } else {
                 writer.write(XMLUtils.escapeXML(val));
@@ -525,9 +526,9 @@ public class XMLWriterImpl implements XMLWriter {
         }
 
         private void insertIndentation() throws IOException {
-            if (XMLWriterPreferences.getInstance().isIndenting()) {
+            if (instance.isIndenting()) {
                 for (int i = 0; i < indentation
-                        * XMLWriterPreferences.getInstance().getIndentSize(); i++) {
+                        * instance.getIndentSize(); i++) {
                     writer.write(' ');
                 }
             }

--- a/parsers/src/main/java/org/coode/xml/XMLWriterPreferences.java
+++ b/parsers/src/main/java/org/coode/xml/XMLWriterPreferences.java
@@ -46,10 +46,17 @@ package org.coode.xml;
  */
 public class XMLWriterPreferences {
 
-    private static XMLWriterPreferences instance = new XMLWriterPreferences();
     private boolean useNamespaceEntities;
     private boolean indenting;
     private int indentSize;
+
+    static ThreadLocal<XMLWriterPreferences> xmlWriterPreferencesThreadLocal = new ThreadLocal<XMLWriterPreferences>() {
+
+        @Override
+        protected XMLWriterPreferences initialValue() {
+            return new XMLWriterPreferences();
+        }
+    };
 
     private XMLWriterPreferences() {
         useNamespaceEntities = false;
@@ -59,7 +66,7 @@ public class XMLWriterPreferences {
 
     /** @return instance */
     public static XMLWriterPreferences getInstance() {
-        return instance;
+        return xmlWriterPreferencesThreadLocal.get();
     }
 
     /** @return use namespace entities */


### PR DESCRIPTION
Use thread locals instead of static variables (issues don't show up in tests until multi-threading is enabled. Then they show up). 
