### PR TITLE
Manimal  - jdk 1.6 compatibility fixes, with maven animal-sniffing...

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/util/CollectionFactory.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/CollectionFactory.java
@@ -317,8 +317,13 @@ public class CollectionFactory {
 
         @Override
         public Iterator<T> iterator() {
-            Set<T> set = backingMap.keySet();
+            Set<T> set = getMapKeySet(backingMap);
             return set.iterator();
+        }
+
+        private  Set<T> getMapKeySet(Map<T, Set<T>> map) {
+            Set<T> keySetView = (Set<T>) map.keySet();
+            return keySetView;
         }
 
         @Override
@@ -355,13 +360,13 @@ public class CollectionFactory {
 
         @Override
         public Object[] toArray() {
-            Set<T> set = backingMap.keySet();
+            Set<T> set = getMapKeySet(backingMap);
             return set.toArray();
         }
 
         @Override
         public <Type> Type[] toArray(Type[] a) {
-            Set<T> set = backingMap.keySet();
+            Set<T> set = getMapKeySet(backingMap);
             return set.toArray(a);
         }
 
@@ -375,9 +380,11 @@ public class CollectionFactory {
                 return true;
             }
             if (obj instanceof SyncSet) {
-                Set<T> set = this.backingMap.keySet();
+                Set<T> set = getMapKeySet(backingMap);
+                SyncSet obj1 = (SyncSet) obj;
+                Set<T> keySetView = getMapKeySet(obj1.backingMap);
                 return set.equals(
-                        ((SyncSet) obj).backingMap.keySet());
+                        keySetView);
             }
             if (obj instanceof Collection) {
                 return new HashSet<T>(this).equals(obj);

--- a/api/src/main/java/org/semanticweb/owlapi/util/CollectionFactory.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/CollectionFactory.java
@@ -317,7 +317,8 @@ public class CollectionFactory {
 
         @Override
         public Iterator<T> iterator() {
-            return backingMap.keySet().iterator();
+            Set<T> set = backingMap.keySet();
+            return set.iterator();
         }
 
         @Override
@@ -342,7 +343,8 @@ public class CollectionFactory {
         @Override
         public boolean retainAll(Collection<?> c) {
             boolean toReturn = false;
-            for (Map.Entry<T, Set<T>> e : backingMap.entrySet()) {
+            Set<Map.Entry<T, Set<T>>> entries = backingMap.entrySet();
+            for (Map.Entry<T, Set<T>> e : entries) {
                 if (!c.contains(e.getKey())) {
                     toReturn = true;
                     backingMap.remove(e.getKey());
@@ -353,12 +355,14 @@ public class CollectionFactory {
 
         @Override
         public Object[] toArray() {
-            return backingMap.keySet().toArray();
+            Set<T> set = backingMap.keySet();
+            return set.toArray();
         }
 
         @Override
         public <Type> Type[] toArray(Type[] a) {
-            return backingMap.keySet().toArray(a);
+            Set<T> set = backingMap.keySet();
+            return set.toArray(a);
         }
 
         @SuppressWarnings("rawtypes")
@@ -371,7 +375,8 @@ public class CollectionFactory {
                 return true;
             }
             if (obj instanceof SyncSet) {
-                return this.backingMap.keySet().equals(
+                Set<T> set = this.backingMap.keySet();
+                return set.equals(
                         ((SyncSet) obj).backingMap.keySet());
             }
             if (obj instanceof Collection) {

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplBoolean.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplBoolean.java
@@ -195,6 +195,11 @@ public class OWLLiteralImplBoolean extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     protected int compareObjectOfSameType(OWLObject object) {
+        if (object instanceof OWLLiteralImplBoolean) {
+            OWLLiteralImplBoolean aBoolean = (OWLLiteralImplBoolean) object;
+            boolean other = aBoolean.literal;
+            return compareBoolean(literal, other);
+        }
         OWLLiteral other = (OWLLiteral) object;
         int diff = getLiteral().compareTo(other.getLiteral());
         if (diff != 0) {
@@ -204,7 +209,21 @@ public class OWLLiteralImplBoolean extends OWLObjectImpl implements OWLLiteral {
         if (compareTo != 0) {
             return compareTo;
         }
-        return Boolean.compare(literal, other.parseBoolean());
+        return compareBoolean(literal, other.parseBoolean());
+    }
+
+    private static int compareBoolean(boolean a, boolean b) {
+        if (a) {
+            if (b) {
+                return 0;
+            } else {
+                return 1;
+            }
+        } else if (!b) {
+            return 0;
+        } else {
+            return -1;
+        }
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplInteger.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplInteger.java
@@ -195,8 +195,15 @@ public class OWLLiteralImplInteger extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     protected int compareObjectOfSameType(OWLObject object) {
+      int diff = 0;
+        if (object instanceof OWLLiteralImplInteger) {
+            OWLLiteralImplInteger integer = (OWLLiteralImplInteger) object;
+            diff = literal - integer.literal;
+            return diff;
+        }
+
         OWLLiteral other = (OWLLiteral) object;
-        int diff = getLiteral().compareTo(other.getLiteral());
+         diff = getLiteral().compareTo(other.getLiteral());
         if (diff != 0) {
             return diff;
         }
@@ -204,7 +211,8 @@ public class OWLLiteralImplInteger extends OWLObjectImpl implements OWLLiteral {
         if (compareTo != 0) {
             return compareTo;
         }
-        return Integer.compare(literal, other.parseInteger());
+        int otherValue = other.parseInteger();
+        return literal - otherValue;
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -300,6 +300,27 @@
 				</configuration>
 			</plugin>
 
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>animal-sniffer-maven-plugin</artifactId>
+				<version>1.13</version>
+				<executions>
+					<execution>
+						<phase>test</phase>
+						<goals>
+							<goal>check</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<signature>
+						<groupId>org.codehaus.mojo.signature</groupId>
+						<artifactId>java16</artifactId>
+						<version>1.0</version>
+					</signature>
+				</configuration>
+			</plugin>
+
 			<!-- the FindBugs plugin for extra checks -->
 			<!--plugin>
 				<groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
Do not upgrade animal sniffer to 1.14 as it will throw an Null Pointer Exception.

I'm not 100% sure if the comparison code is right WRT OWL/RDF/XSD, but I don't think it's supposed to be. I just care about literals sorting consistently, which is all these methods are for, I believe. Proper ordering by datatype is a job for the reasoner. SEP field engaged.  

