### PR TITLE
SNAFU in owlapi-distribution dependencies;  might require a very very quick release of 3.5.3 (or a sneaky 3.5.2 re-release)

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -18,31 +18,47 @@
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-apibinding</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-api</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-tools</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-impl</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-parsers</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>owlapi-oboformat</artifactId>
 			<version>${project.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>net.sf.trove4j</groupId>
+			<artifactId>trove4j</artifactId>
+			<version>3.0.3</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>[17,19)</version>
 		</dependency>
 	</dependencies>
 
@@ -56,7 +72,8 @@
 				<extensions>true</extensions>
 				<configuration>
 					<instructions>
-						<Bundle-SymbolicName>org.semanticweb.owl.owlapi</Bundle-SymbolicName>
+						<Embed-Dependency>*;scope=provided;inline=true</Embed-Dependency>
+\						<Bundle-SymbolicName>org.semanticweb.owl.owlapi</Bundle-SymbolicName>
 						<Export-Package>
 							com.clarkparsia.*,
 							de.uulm.*,


### PR DESCRIPTION
The scope of the dependencies is specified as provided, so all the sub-jars will be grabbed by maven in addition  addition to the distribution.

The only  difference between this jar and owlapi-osgidistribuion (apart from the hack classes) is that the other distribution has trove and guava embedded, whereas this distribution has them as maven dependencies.

Also, why did all the individual  sub-projects get turned into jars instead of bundles?
 It was shade that was including all the dependents, not bundle. 