### PR TITLE
Enforce correct argument types for OWLObjectInverseProperty in default impl 

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLObjectPropertyExpression.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLObjectPropertyExpression.java
@@ -40,26 +40,25 @@ public interface OWLObjectPropertyExpression extends OWLPropertyExpression,
     /**
      * Obtains the property that corresponds to the inverse of this property.
      * 
-     * @return The inverse of this property. Note that this property will not
-     *         necessarily be in the simplest form.
+     * @return The inverse of this property.
      */
     @Nonnull
     OWLObjectPropertyExpression getInverseProperty();
 
     /**
      * Returns this property in its simplified form.
-     * 
-     * @return Let p be a property name and PE an object property expression.
-     *         The simplification, 'simp', is defined as follows: simp(p) = p
-     *         simp(inv(p)) = inv(p) simp(inv(inv(PE)) = simp(PE)
+     * @deprecated Since it is not legal to apply ObjectInverseOf to anything other than an Object Property,
+     * all object properties are always in the simpled form.
+     *
      */
+    @Deprecated
     @Nonnull
     OWLObjectPropertyExpression getSimplified();
 
     /**
      * Get the named object property used in this property expression.
      * 
-     * @return P if simp(PE) = inv(P) or P if simp(PE) = P.
+     * @return P if PE = inv(P) otherwise PE.
      */
     @Nonnull
     OWLObjectProperty getNamedProperty();

--- a/api/src/main/java/org/semanticweb/owlapi/util/ObjectPropertySimplifier.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/ObjectPropertySimplifier.java
@@ -29,11 +29,19 @@ import org.semanticweb.owlapi.model.OWLPropertyExpressionVisitor;
  * simplest form. Let P be an object property name and PE a property expression,
  * then the simplification is inductively defined as: simp(P) = P simp(inv(P)) =
  * inv(P) simp(inv(inv(PE)) = simp(PE)
- * 
+ *
+ *
  * @author Matthew Horridge, The University Of Manchester, Information
  *         Management Group
  * @since 2.2.0
+ *
+ * @deprecated Legal Object property expressions should always be irreducible - the standard specifies that
+ * inv : P -> PE , not PE -> PE, so inv (inv P) is an error .
+ * Versions of the OWLAPI  prior to 4.1.0 did not check for this.
+ *
+
  */
+@Deprecated
 public class ObjectPropertySimplifier {
 
     @Nonnull

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/objectproperties/ObjectPropertySimplifierTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/objectproperties/ObjectPropertySimplifierTestCase.java
@@ -38,7 +38,7 @@ public class ObjectPropertySimplifierTestCase extends TestBase {
     @Test
     public void testInverseSimplification() {
         OWLObjectProperty p = ObjectProperty(IRI("p"));
-        OWLObjectPropertyExpression inv = ObjectInverseOf(p);
+        OWLObjectPropertyExpression inv = p.getInverseProperty();
         OWLObjectPropertyExpression exp = inv.getSimplified();
         assertEquals(inv, exp);
     }
@@ -46,8 +46,8 @@ public class ObjectPropertySimplifierTestCase extends TestBase {
     @Test
     public void testInverseInverseSimplification() {
         OWLObjectProperty p = ObjectProperty(IRI("p"));
-        OWLObjectPropertyExpression inv = ObjectInverseOf(p);
-        OWLObjectPropertyExpression inv2 = ObjectInverseOf(inv);
+        OWLObjectPropertyExpression inv = p.getInverseProperty();
+        OWLObjectPropertyExpression inv2 = inv.getInverseProperty();
         OWLObjectPropertyExpression exp = inv2.getSimplified();
         assertEquals(p, exp);
     }
@@ -55,9 +55,9 @@ public class ObjectPropertySimplifierTestCase extends TestBase {
     @Test
     public void testInverseInverseInverseSimplification() {
         OWLObjectProperty p = ObjectProperty(IRI("p"));
-        OWLObjectPropertyExpression inv = ObjectInverseOf(p);
-        OWLObjectPropertyExpression inv2 = ObjectInverseOf(inv);
-        OWLObjectPropertyExpression inv3 = ObjectInverseOf(inv2);
+        OWLObjectPropertyExpression inv = p.getInverseProperty();
+        OWLObjectPropertyExpression inv2 = inv.getInverseProperty();
+        OWLObjectPropertyExpression inv3 = inv2.getInverseProperty();
         OWLObjectPropertyExpression exp = inv3.getSimplified();
         assertEquals(inv, exp);
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryImpl.java
@@ -1556,6 +1556,9 @@ public class OWLDataFactoryImpl implements OWLDataFactory, Serializable,
     public OWLObjectInverseOf getOWLObjectInverseOf(
             OWLObjectPropertyExpression property) {
         checkNotNull(property, "property cannot be null");
+        if(!(property instanceof OWLObjectProperty)) {
+            throw new IllegalArgumentException("ObjectInverseOf can only be applied to Object Properties");
+        }
         return new OWLObjectInverseOfImpl(property);
     }
 

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectInverseOfImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectInverseOfImpl.java
@@ -45,7 +45,7 @@ public class OWLObjectInverseOfImpl extends OWLObjectPropertyExpressionImpl
     }
 
     @Nonnull
-    private final OWLObjectPropertyExpression inverseProperty;
+    private final OWLObjectProperty inverseProperty;
 
     /**
      * @param inverseProperty
@@ -53,7 +53,11 @@ public class OWLObjectInverseOfImpl extends OWLObjectPropertyExpressionImpl
      */
     public OWLObjectInverseOfImpl(
             @Nonnull OWLObjectPropertyExpression inverseProperty) {
-        this.inverseProperty = inverseProperty;
+        if(!(inverseProperty instanceof OWLObjectProperty)) {
+            throw new IllegalArgumentException("ObjectInverseOf can only be applied to Object Properties");
+        }
+
+        this.inverseProperty = inverseProperty.asOWLObjectProperty();
     }
 
     @Override
@@ -66,8 +70,20 @@ public class OWLObjectInverseOfImpl extends OWLObjectPropertyExpressionImpl
         addAnonymousIndividualsToSetForValue(anons, inverseProperty);
     }
 
+    @Nonnull
     @Override
-    public OWLObjectPropertyExpression getInverse() {
+    public OWLObjectPropertyExpression getInverseProperty() {
+        return getInverse();
+    }
+
+    @Override
+    public OWLObjectProperty getInverse() {
+        return inverseProperty;
+    }
+
+    @Nonnull
+    @Override
+    public OWLObjectProperty getNamedProperty() {
         return inverseProperty;
     }
 

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectPropertyExpressionImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectPropertyExpressionImpl.java
@@ -12,14 +12,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package uk.ac.manchester.cs.owl.owlapi;
 
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
-
 import javax.annotation.Nonnull;
-
-import org.semanticweb.owlapi.model.OWLObjectInverseOf;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
-import org.semanticweb.owlapi.util.ObjectPropertySimplifier;
 
 /**
  * @author Matthew Horridge, The University Of Manchester, Bio-Health
@@ -57,31 +51,7 @@ public abstract class OWLObjectPropertyExpressionImpl extends
     @Nonnull
     @Override
     public OWLObjectPropertyExpression getSimplified() {
-        if (simplestForm == null) {
-            ObjectPropertySimplifier simplifier = new ObjectPropertySimplifier(
-                    new OWLDataFactoryImpl());
-            simplestForm = simplifier.getSimplified(this);
-        }
-        return verifyNotNull(simplestForm);
+        return this;
     }
 
-    @Nonnull
-    @Override
-    public OWLObjectPropertyExpression getInverseProperty() {
-        if (inverse == null) {
-            inverse = new OWLObjectInverseOfImpl(this);
-        }
-        return verifyNotNull(inverse);
-    }
-
-    @Override
-    public OWLObjectProperty getNamedProperty() {
-        OWLObjectPropertyExpression simp = getSimplified();
-        if (simp.isAnonymous()) {
-            return ((OWLObjectInverseOf) simp).getInverse()
-                    .asOWLObjectProperty();
-        } else {
-            return simp.asOWLObjectProperty();
-        }
-    }
 }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectPropertyImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLObjectPropertyImpl.java
@@ -12,32 +12,13 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package uk.ac.manchester.cs.owl.owlapi;
 
+import org.semanticweb.owlapi.model.*;
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
 import java.util.Set;
 
 import javax.annotation.Nonnull;
 
-import org.semanticweb.owlapi.model.EntityType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDatatype;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLEntityVisitor;
-import org.semanticweb.owlapi.model.OWLEntityVisitorEx;
-import org.semanticweb.owlapi.model.OWLNamedIndividual;
-import org.semanticweb.owlapi.model.OWLNamedObjectVisitor;
-import org.semanticweb.owlapi.model.OWLNamedObjectVisitorEx;
-import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLObjectVisitor;
-import org.semanticweb.owlapi.model.OWLObjectVisitorEx;
-import org.semanticweb.owlapi.model.OWLPropertyExpressionVisitor;
-import org.semanticweb.owlapi.model.OWLPropertyExpressionVisitorEx;
-import org.semanticweb.owlapi.model.OWLRuntimeException;
 import org.semanticweb.owlapi.util.OWLObjectTypeIndexProvider;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
 
@@ -68,6 +49,18 @@ public class OWLObjectPropertyImpl extends OWLObjectPropertyExpressionImpl
         builtin = iri.equals(OWLRDFVocabulary.OWL_TOP_OBJECT_PROPERTY.getIRI())
                 || iri.equals(OWLRDFVocabulary.OWL_BOTTOM_OBJECT_PROPERTY
                         .getIRI());
+    }
+
+    @Nonnull
+    @Override
+    public OWLObjectInverseOf getInverseProperty() {
+        return new OWLObjectInverseOfImpl(this);
+    }
+
+    @Nonnull
+    @Override
+    public OWLObjectProperty getNamedProperty() {
+        return this;
     }
 
     @Override


### PR DESCRIPTION
See Issue #430 .

Parsers have not been changed. 