### PR TITLE
Integrate with Commons RDF API for RDF concepts

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,5 +14,10 @@
 			<artifactId>xz</artifactId>
 			<version>1.5</version>
 		</dependency>
+	  <dependency>
+	      <groupId>org.apache.commons</groupId>
+	      <artifactId>commons-rdf-api</artifactId>
+	      <version>0.1.0-incubating</version>
+	  </dependency>
 	</dependencies>
 </project>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -14,10 +14,17 @@
 			<artifactId>xz</artifactId>
 			<version>1.5</version>
 		</dependency>
-	  <dependency>
-	      <groupId>org.apache.commons</groupId>
-	      <artifactId>commons-rdf-api</artifactId>
-	      <version>0.1.0-incubating</version>
-	  </dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-rdf-api</artifactId>
+			<version>0.1.0-incubating</version>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-rdf-api</artifactId>
+			<version>0.1.0-incubating</version>
+			<classifier>tests</classifier>
+			<scope>test</scope>
+		</dependency>	  
 	</dependencies>
 </project>

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -188,7 +188,8 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
   		String escaped = '"' +
   				EscapeUtils.escapeString(getLexicalValue()).
   				replace("\n", "\\n").replace("\r", "\\r") + '"';
-  		if (datatype.equals(OWL2Datatype.RDF_PLAIN_LITERAL.getIRI())) {
+  		if (datatype.equals(OWL2Datatype.RDF_PLAIN_LITERAL.getIRI()) || 
+  			datatype.equals(OWL2Datatype.XSD_STRING.getIRI())) {
   			return escaped;
   		} else if (hasLang()) {
   			return escaped + "@" + getLang();

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -19,6 +19,7 @@ import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.rdf.api.Literal;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.util.EscapeUtils;
@@ -82,17 +83,33 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
         if (obj == this) {
             return true;
         }
-        if (!(obj instanceof RDFLiteral)) {
-            return false;
+        if (obj instanceof RDFLiteral) {            
+	        RDFLiteral other = (RDFLiteral) obj;
+	        if (!lexicalValue.equals(other.lexicalValue)) {
+	            return false;
+	        }
+	        if (!lang.equals(other.lang)) {
+	            return false;
+	        }
+	        return datatype.equals(other.datatype);
         }
-        RDFLiteral other = (RDFLiteral) obj;
-        if (!lexicalValue.equals(other.lexicalValue)) {
-            return false;
+        if (obj instanceof Literal) {
+        	// Note: This also works on RDFLiteral
+        	// but is slightly more expensive as it must call the 
+        	// getter methods when accessing obj.
+        	// 
+        	// To ensure future compatibility, the Commons RDF getter 
+        	// methods are also called on this rather than using the fields.
+			Literal literal = (Literal) obj;
+        	if (! getLexicalForm().equals(((Literal) obj).getLexicalForm())) {
+        		return false;
+        	}
+        	if (! getLanguageTag().equals(literal.getLanguageTag())) {
+        		return false;
+        	}
+        	return getDatatype().equals(literal.getDatatype());        	
         }
-        if (!lang.equals(other.lang)) {
-            return false;
-        }
-        return datatype.equals(other.datatype);
+        return false;
     }
 
     @Override

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -14,11 +14,14 @@ package org.semanticweb.owlapi.io;
 
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
+import java.util.Optional;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLLiteral;
+import org.semanticweb.owlapi.util.EscapeUtils;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 /**
@@ -26,7 +29,7 @@ import org.semanticweb.owlapi.vocab.OWL2Datatype;
  *         Informatics Group
  * @since 3.2
  */
-public class RDFLiteral extends RDFNode {
+public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Literal {
 
     private final @Nonnull String lexicalValue;
     private final @Nonnull String lang;
@@ -109,10 +112,28 @@ public class RDFLiteral extends RDFNode {
     }
 
     /**
+     * {@inheritDoc}
+     */
+  	@Override
+  	public String getLexicalForm() {
+  		return getLexicalValue();
+  	}
+
+    /**
      * @return the lang tag for this literal
      */
     public String getLang() {
         return lang;
+    }
+
+    @Override
+    public Optional<String> getLanguageTag() {
+    	if (hasLang()) {
+    		return Optional.of(lang);
+    	} else {
+    		return Optional.empty();
+    	}
+
     }
 
     /**
@@ -157,4 +178,20 @@ public class RDFLiteral extends RDFNode {
         }
         return diff;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+  	@Override
+  	public String ntriplesString() {
+  		String escaped = '"' +
+  				EscapeUtils.escapeString(getLexicalValue()).
+  				replace("\n", "\\n").replace("\r", "\\r") + '"';
+  		if (hasLang()) {
+  			return escaped + "@" + getLang();
+  		} else {
+  			return escaped + "^^" + getDatatype().ntriplesString();
+  		}
+  	}
+
 }

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -49,7 +49,8 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
     public RDFLiteral(String literal, @Nullable String lang, @Nullable IRI datatype) {
         lexicalValue = checkNotNull(literal, "literal cannot be null");
         this.lang = lang == null ? "" : lang;
-        this.datatype = datatype == null ? OWL2Datatype.RDF_PLAIN_LITERAL.getIRI() : datatype;
+        OWL2Datatype defaultType = this.lang.isEmpty() ? OWL2Datatype.RDF_PLAIN_LITERAL : OWL2Datatype.RDF_LANG_STRING;
+        this.datatype = datatype == null ? defaultType.getIRI() : datatype;
     }
 
     /**
@@ -187,7 +188,9 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
   		String escaped = '"' +
   				EscapeUtils.escapeString(getLexicalValue()).
   				replace("\n", "\\n").replace("\r", "\\r") + '"';
-  		if (hasLang()) {
+  		if (datatype.equals(OWL2Datatype.RDF_PLAIN_LITERAL.getIRI())) {
+  			return escaped;
+  		} else if (hasLang()) {
   			return escaped + "@" + getLang();
   		} else {
   			return escaped + "^^" + getDatatype().ntriplesString();

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFNode.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFNode.java
@@ -22,7 +22,7 @@ import org.semanticweb.owlapi.model.HasIRI;
  * @since 3.2
  */
 public abstract class RDFNode implements Serializable, Comparable<RDFNode>,
-        HasIRI {
+        HasIRI, org.apache.commons.rdf.api.RDFTerm {
 
     /**
      * Determines if this node is a literal node.

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResource.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResource.java
@@ -23,7 +23,7 @@ import org.semanticweb.owlapi.model.IRI;
  *         Informatics Group
  * @since 3.2
  */
-public abstract class RDFResource extends RDFNode {
+public abstract class RDFResource extends RDFNode implements org.apache.commons.rdf.api.BlankNodeOrIRI {
 
     // XXX implement equals()
     /**
@@ -60,4 +60,11 @@ public abstract class RDFResource extends RDFNode {
         }
         return diff;
     }
+    
+	@Override
+	public String ntriplesString() {
+		return getResource().ntriplesString();
+	}
+
+
 }

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.rdf.api.BlankNode;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.NodeID;
 
@@ -94,11 +95,16 @@ public class RDFResourceBlankNode extends RDFResource implements org.apache.comm
         if (obj == this) {
             return true;
         }
-        if (!(obj instanceof RDFResourceBlankNode)) {
-            return false;
+        if (obj instanceof RDFResourceBlankNode) {
+            RDFResourceBlankNode other = (RDFResourceBlankNode) obj;
+            return resource.equals(other.resource);            
         }
-        RDFResourceBlankNode other = (RDFResourceBlankNode) obj;
-        return resource.equals(other.resource);
+        // Commons RDF BlankNode.equals() contract
+        if (obj instanceof BlankNode) {
+        	BlankNode blankNode = (BlankNode) obj;
+			return uniqueReference().equals(blankNode.uniqueReference());
+        }
+        return false;
     }
 
     @Override

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
@@ -14,6 +14,8 @@ package org.semanticweb.owlapi.io;
 
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
+import java.util.UUID;
+
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -21,15 +23,20 @@ import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.NodeID;
 
 /** Anonymous node implementation. */
-public class RDFResourceBlankNode extends RDFResource {
+public class RDFResourceBlankNode extends RDFResource implements org.apache.commons.rdf.api.BlankNode {
 
     private final @Nonnull IRI resource;
     private final boolean isIndividual;
     private final boolean forceIdOutput;
 
     /**
+     * Random UUID, used by {@link #uniqueReference()}
+     */
+    private static final UUID UNIQUE_BASE = UUID.randomUUID();
+
+    /**
      * Create an RDFResource that is anonymous.
-     * 
+     *
      * @param resource
      *        The IRI of the resource
      * @param isIndividual
@@ -108,4 +115,18 @@ public class RDFResourceBlankNode extends RDFResource {
     public IRI getResource() {
         return resource;
     }
+
+  	@Override
+  	public String uniqueReference() {
+  		String nodeId;
+  		if (NodeID.isAnonymousNodeIRI(resource)) {
+  			nodeId = resource.getRemainder().orElse("");
+  		} else {
+  			// Not made from NodeID, so we won't assume much, but still include
+  			// the UUID as we can't assume a globally unique IRI
+  			nodeId = resource.getIRIString().replace("_:", "");
+  		}
+  		return UNIQUE_BASE + ":" + nodeId;
+  	}
+
 }

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceBlankNode.java
@@ -118,14 +118,7 @@ public class RDFResourceBlankNode extends RDFResource implements org.apache.comm
 
   	@Override
   	public String uniqueReference() {
-  		String nodeId;
-  		if (NodeID.isAnonymousNodeIRI(resource)) {
-  			nodeId = resource.getRemainder().orElse("");
-  		} else {
-  			// Not made from NodeID, so we won't assume much, but still include
-  			// the UUID as we can't assume a globally unique IRI
-  			nodeId = resource.getIRIString().replace("_:", "");
-  		}
+  		String nodeId = resource.getIRIString().replace("_:", "");
   		return UNIQUE_BASE + ":" + nodeId;
   	}
 

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceIRI.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceIRI.java
@@ -20,7 +20,7 @@ import javax.annotation.Nullable;
 import org.semanticweb.owlapi.model.IRI;
 
 /** IRI node implementation. */
-public class RDFResourceIRI extends RDFResource {
+public class RDFResourceIRI extends RDFResource implements org.apache.commons.rdf.api.IRI {
 
     private final @Nonnull IRI resource;
 
@@ -63,4 +63,10 @@ public class RDFResourceIRI extends RDFResource {
     public String toString() {
         return resource.toQuotedString();
     }
+
+    @Override
+  	public String getIRIString() {
+  		  return resource.getIRIString();
+  	}
+
 }

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceIRI.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFResourceIRI.java
@@ -51,12 +51,17 @@ public class RDFResourceIRI extends RDFResource implements org.apache.commons.rd
     public boolean equals(@Nullable Object obj) {
         if (obj == this) {
             return true;
+        }        
+        if (obj instanceof RDFResourceIRI) {            
+	        RDFResourceIRI other = (RDFResourceIRI) obj;
+	        return resource.equals(other.resource);
         }
-        if (!(obj instanceof RDFResourceIRI)) {
-            return false;
+        // Commons RDF IRI equals() contract
+        if (obj instanceof org.apache.commons.rdf.api.IRI) {
+        	org.apache.commons.rdf.api.IRI iri = (org.apache.commons.rdf.api.IRI) obj;
+			return ntriplesString().equals(iri.ntriplesString());
         }
-        RDFResourceIRI other = (RDFResourceIRI) obj;
-        return resource.equals(other.resource);
+        return false;
     }
 
     @Override

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFTriple.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFTriple.java
@@ -24,6 +24,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.rdf.api.Triple;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
@@ -125,11 +126,24 @@ public class RDFTriple implements Serializable, Comparable<RDFTriple>, org.apach
         if (obj == this) {
             return true;
         }
-        if (!(obj instanceof RDFTriple)) {
-            return false;
+        if (obj instanceof RDFTriple) {
+        	RDFTriple other = (RDFTriple) obj;
+        	return subject.equals(other.subject) && predicate.equals(other.predicate) && object.equals(other.object);            
         }
-        RDFTriple other = (RDFTriple) obj;
-        return subject.equals(other.subject) && predicate.equals(other.predicate) && object.equals(other.object);
+        // Commons RDF Triple.equals() contract
+        if (obj instanceof Triple) {
+        	// Note: This also works on RDFLiteral
+        	// but is slightly more expensive as it must call the 
+        	// getter methods when accessing obj.
+        	// 
+        	// To ensure future compatibility, the Commons RDF getter 
+        	// methods are also called on this rather than using the fields.
+			Triple triple = (Triple) obj;
+        	return getSubject().equals(triple.getSubject()) && 
+        			getPredicate().equals(triple.getPredicate()) &&
+        			getObject().equals(triple.getObject());
+        }
+        return false;
     }
 
     @Override

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFTriple.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFTriple.java
@@ -35,7 +35,7 @@ import gnu.trove.map.hash.THashMap;
  *         Informatics Group
  * @since 3.2
  */
-public class RDFTriple implements Serializable, Comparable<RDFTriple> {
+public class RDFTriple implements Serializable, Comparable<RDFTriple>, org.apache.commons.rdf.api.Triple {
 
     private final @Nonnull RDFResource subject;
     private final @Nonnull RDFResourceIRI predicate;

--- a/api/src/main/java/org/semanticweb/owlapi/model/IRI.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/IRI.java
@@ -464,11 +464,16 @@ public class IRI
         if (obj == this) {
             return true;
         }
-        if (!(obj instanceof IRI)) {
-            return false;
+        if (obj instanceof IRI) {
+	        IRI other = (IRI) obj;
+	        return remainder.equals(other.remainder) && other.namespace.equals(namespace);
         }
-        IRI other = (IRI) obj;
-        return remainder.equals(other.remainder) && other.namespace.equals(namespace);
+        // Commons RDF IRI equals() contract
+        if (obj instanceof org.apache.commons.rdf.api.IRI) {
+        	org.apache.commons.rdf.api.IRI iri = (org.apache.commons.rdf.api.IRI) obj;
+			return ntriplesString().equals(iri.ntriplesString());
+        }
+        return false;        
     }
 
   	@Override

--- a/api/src/main/java/org/semanticweb/owlapi/model/IRI.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/IRI.java
@@ -36,7 +36,7 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
  * @since 3.0.0
  */
 public class IRI
-    implements OWLAnnotationSubject, OWLAnnotationValue, SWRLPredicate, CharSequence, OWLPrimitive, HasShortForm {
+    implements OWLAnnotationSubject, OWLAnnotationValue, SWRLPredicate, CharSequence, OWLPrimitive, HasShortForm, org.apache.commons.rdf.api.IRI {
 
     /**
      * Obtains this IRI as a URI. Note that Java URIs handle unicode characters,
@@ -183,7 +183,7 @@ public class IRI
      * @return This IRI surrounded by &lt; and &gt;
      */
     public String toQuotedString() {
-        return '<' + namespace + remainder + '>';
+        return ntriplesString();
     }
 
     /**
@@ -433,10 +433,7 @@ public class IRI
 
     @Override
     public String toString() {
-        if (remainder.isEmpty()) {
-            return namespace;
-        }
-        return namespace + remainder;
+    	return getIRIString();
     }
 
     @Override
@@ -473,4 +470,17 @@ public class IRI
         IRI other = (IRI) obj;
         return remainder.equals(other.remainder) && other.namespace.equals(namespace);
     }
+
+  	@Override
+  	public String ntriplesString() {
+  		return '<' + namespace + remainder + '>';
+  	}
+
+  	@Override
+  	public String getIRIString() {
+          if (remainder.isEmpty()) {
+              return namespace;
+          }
+          return namespace + remainder;
+  	}
 }

--- a/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
+++ b/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
@@ -43,7 +43,8 @@ public enum OWL2Datatype implements HasIRI,HasShortForm,HasPrefixedName {
 //@formatter:off
     /** RDF_XML_LITERAL. */          RDF_XML_LITERAL          (RDF,  "XMLLiteral",   Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"), 
     /** RDFS_LITERAL. */             RDFS_LITERAL             (RDFS, "Literal",      Category.CAT_UNIVERSAL,                   false, ".*"),
-    /** RDF_PLAIN_LITERAL. */        RDF_PLAIN_LITERAL        (RDF,  "PlainLiteral", Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),
+    /** RDF_PLAIN_LITERAL. */        RDF_PLAIN_LITERAL        (RDF,  "PlainLiteral", Category.CAT_STRING_WITH_LANGUAGE_TAG,    false, ".*"),
+    /** RDF_LANG_STRING. */          RDF_LANG_STRING          (RDF,  "langString",   Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),
     /** OWL_REAL. */                 OWL_REAL                 (OWL,  "real",         Category.CAT_NUMBER,                      false, ".*"),
     /** OWL_RATIONAL. */             OWL_RATIONAL             (OWL,  "rational",     Category.CAT_NUMBER,                      false, "(\\+|-)?([0-9]+)(\\s)*(/)(\\s)*([0-9]+)"),
     /** XSD_STRING. */               XSD_STRING               (STRING,               Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),

--- a/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
+++ b/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
@@ -63,8 +63,8 @@ public class CommonsRDFTermTest extends AbstractRDFTermFactoryTest {
 		@Override
 		public Triple createTriple(BlankNodeOrIRI subject, org.apache.commons.rdf.api.IRI predicate, RDFTerm object)
 				throws IllegalArgumentException, UnsupportedOperationException {
+			RDFResource subject2 = (RDFResource) convert(subject);
 			RDFResourceIRI predicate2 = (RDFResourceIRI) convert(predicate);
-			RDFResource subject2 = (RDFResource) convert(predicate);
 			RDFNode object2 = convert(object);
 			return new RDFTriple(subject2, predicate2, object2);
 		}

--- a/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
+++ b/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
@@ -14,8 +14,12 @@ import org.apache.commons.rdf.api.Literal;
 import org.apache.commons.rdf.api.RDFTerm;
 import org.apache.commons.rdf.api.RDFTermFactory;
 import org.apache.commons.rdf.api.Triple;
-
+import org.junit.Assert;
+import org.junit.Assume;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.semanticweb.owlapi.model.NodeID;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 public class CommonsRDFTermTest extends AbstractRDFTermFactoryTest {
 
@@ -37,7 +41,7 @@ public class CommonsRDFTermTest extends AbstractRDFTermFactoryTest {
 		@Override
 		public RDFLiteral createLiteral(String lexicalForm)
 				throws IllegalArgumentException, UnsupportedOperationException {
-			return new RDFLiteral(lexicalForm, null, null);
+			return new RDFLiteral(lexicalForm, null, OWL2Datatype.XSD_STRING.getIRI());
 		}
 		
 		@Override
@@ -115,4 +119,30 @@ public class CommonsRDFTermTest extends AbstractRDFTermFactoryTest {
 		return new OWLAPIRDFTermFactory();
 	}
 
+	
+	@Ignore
+    @Test
+    public void testPossiblyInvalidBlankNode() throws Exception {
+		// FIXME: Should BlankNode identifiers be validated? At least
+		// ntriplesString() output should be checked - but could 
+		// this also affect load/save issues?
+    	Assume.assumeTrue("BlankNode identifiers are not validated", false);
+		super.testPossiblyInvalidBlankNode();
+    	
+    }
+
+	@Ignore
+	@Override
+	public void testInvalidLiteralLang() throws Exception {
+		// FIXME: RDFLiteral should not allow spaces in lang
+		Assume.assumeTrue("RDFLiteral does not validate lang", false);
+		super.testInvalidLiteralLang();
+	}
+	
+	@Ignore
+	@Override
+	public void testInvalidIRI() throws Exception {
+		Assume.assumeTrue("IRI string is not validated", false);
+		super.testInvalidIRI();
+	}
 }

--- a/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
+++ b/api/src/test/java/org/semanticweb/owlapi/io/CommonsRDFTermTest.java
@@ -1,0 +1,118 @@
+package org.semanticweb.owlapi.io;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.rdf.api.AbstractRDFTermFactoryTest;
+import org.apache.commons.rdf.api.BlankNode;
+import org.apache.commons.rdf.api.BlankNodeOrIRI;
+import org.apache.commons.rdf.api.Literal;
+
+// NOTE: Always fully qualified IRI  to avoid confusion between
+//import org.apache.commons.rdf.api.IRI;
+//import org.semanticweb.owlapi.model.IRI;
+
+import org.apache.commons.rdf.api.RDFTerm;
+import org.apache.commons.rdf.api.RDFTermFactory;
+import org.apache.commons.rdf.api.Triple;
+
+import org.semanticweb.owlapi.model.NodeID;
+
+public class CommonsRDFTermTest extends AbstractRDFTermFactoryTest {
+
+	private final class OWLAPIRDFTermFactory implements RDFTermFactory {
+		
+		private AtomicInteger bnodeCounter = new AtomicInteger();
+		
+		@Override
+		public RDFResourceBlankNode createBlankNode()  {			
+			return new RDFResourceBlankNode(bnodeCounter.incrementAndGet(), false, false);
+		}
+		
+		@Override
+		public RDFResourceBlankNode createBlankNode(String name)  {			
+			org.semanticweb.owlapi.model.IRI iri = createIRI(NodeID.getIRIFromNodeID(name));
+			return new RDFResourceBlankNode(iri, false, false);
+		}
+		
+		@Override
+		public RDFLiteral createLiteral(String lexicalForm)
+				throws IllegalArgumentException, UnsupportedOperationException {
+			return new RDFLiteral(lexicalForm, null, null);
+		}
+		
+		@Override
+		public RDFLiteral createLiteral(String lexicalForm, org.apache.commons.rdf.api.IRI dataType)
+				throws IllegalArgumentException, UnsupportedOperationException {
+			return new RDFLiteral(lexicalForm, null, createIRI(dataType.getIRIString()));
+		}
+
+		@Override
+		public RDFLiteral createLiteral(String lexicalForm, String languageTag)
+				throws IllegalArgumentException, UnsupportedOperationException {			
+			return new RDFLiteral(lexicalForm, languageTag, null);
+		}
+		
+		@Override
+		public org.semanticweb.owlapi.model.IRI createIRI(String iriStr) throws IllegalArgumentException, UnsupportedOperationException {
+			org.semanticweb.owlapi.model.IRI innerIri = org.semanticweb.owlapi.model.IRI.create(iriStr);			// 
+			return innerIri;
+			// TODO: What about RDFResourceIRI?
+			//return new RDFResourceIRI(innerIri);
+		}
+		
+		@Override
+		public Triple createTriple(BlankNodeOrIRI subject, org.apache.commons.rdf.api.IRI predicate, RDFTerm object)
+				throws IllegalArgumentException, UnsupportedOperationException {
+			RDFResourceIRI predicate2 = (RDFResourceIRI) convert(predicate);
+			RDFResource subject2 = (RDFResource) convert(predicate);
+			RDFNode object2 = convert(object);
+			return new RDFTriple(subject2, predicate2, object2);
+		}
+
+		private RDFNode convert(RDFTerm term) {
+			if (term instanceof RDFNode) {
+				// NOTE: Naively assuming it can then be further casted to RDFResourceIRI etc
+				return (RDFNode)term;
+			}
+			if (term instanceof org.apache.commons.rdf.api.IRI) {
+				org.apache.commons.rdf.api.IRI iri = (org.apache.commons.rdf.api.IRI)term;
+				return new RDFResourceIRI(createIRI(iri.getIRIString()));
+			}
+			if (term instanceof BlankNode) {				
+				BlankNode blankNode = (BlankNode) term;
+				String ntriples = blankNode.ntriplesString();
+				org.semanticweb.owlapi.model.IRI iriLike;
+				if (ntriples.startsWith("<") && ntriples.endsWith(">")) {
+					// strange.. a BlankNode with IRI? Well, we can handle those.
+					iriLike = createIRI(ntriples.substring(1, ntriples.length()-1));					
+				} else if (ntriples.startsWith("_:")) {
+					// org.semanticweb.owlapi.model.IRI supports these directly
+					// even though they are not relly IRIs
+					iriLike = createIRI(ntriples);
+				} else {
+					// How can this be valid N-Triples?
+					throw new IllegalArgumentException("Unsupported ntriplesString on BlankNode: " + ntriples);
+				}
+				return new RDFResourceBlankNode(iriLike, false, false);
+			}
+			if (term instanceof Literal) {
+				Literal literal = (Literal) term;
+				org.semanticweb.owlapi.model.IRI dataType = null;
+				if (! literal.getLanguageTag().isPresent()) {
+					dataType = createIRI(literal.getDatatype().getIRIString());
+				}
+				return new RDFLiteral(literal.getLexicalForm(), 
+						literal.getLanguageTag().orElse(null), 
+						dataType);
+			}
+			throw new IllegalArgumentException("Unsupported type: " + term.getClass());
+		}
+		
+	}
+
+	@Override
+	public RDFTermFactory createFactory() {
+		return new OWLAPIRDFTermFactory();
+	}
+
+}


### PR DESCRIPTION
[Apache Commons RDF](http://commonsrdf.incubator.apache.org/) (incubating) is an effort for making a common API (e.g. Java interfaces) for RDF concepts like [`IRI`](http://commonsrdf.incubator.apache.org/apidocs/org/apache/commons/rdf/api/IRI.html) and [`BlankNode`](http://commonsrdf.incubator.apache.org/apidocs/org/apache/commons/rdf/api/Literal.html). Commons RDF aims to become a common interface between frameworks like Jena and Sesame so that you can have direct API compatibility without having to serialize and deserialize RDF. 

## Motivation

* Commons RDF tries to stay as close as possible to the [RDF 1.1 concepts](http://www.w3.org/TR/rdf11-concepts/) and to be neutral common ground between the Java RDF frameworks.
* The Commons RDF API is now stabilizing, although we appreciate any [feedback](http://commonsrdf.incubator.apache.org/contributing.html) or suggested modifications before releasing 1.0.0.
* Commons RDF integration is planned in most of the Java framework projects, e.g. Apache Jena [JENA-1015](https://issues.apache.org/jira/browse/JENA-1015), Sesame [SES-2091](https://openrdf.atlassian.net/browse/SES-2091) and Apache Clerezza.
* Integrating Commons RDF with OWLAPI means that users (and OWLAPI) has the potential to combine the two in a more direct way, and can use parsers, writers and triple stores from these frameworks.   

## Implementation

This patch shows the OWLAPI modifications needed to the types `RDFLiteral`, `RDFResource`, `RDFNode`, `RDFLiteral`, `RDFTriple` and `IRI`.  Changes are generally minimal, as the overlap was already big.

OWLAPI doesn't really have the concept of a `Graph` as statements are generated or consumed on the fly.

OWLAPI has both `IRI` and `RDFResourceIRI` - I am not sure why both are needed, but it was easy enough to make both of them compatible with Common RDF's `IRI`.

Note that Commons RDF also expects [.equals()](http://commonsrdf.incubator.apache.org/apidocs/org/apache/commons/rdf/api/IRI.html#equals-java.lang.Object-) to work across implementations on the core concepts, so therefore this patch also modifies OWLAPI .equals() to support a fallback to other Common RDF instances. 

I included a `CommonsRDFTermTest` to use Common RDF test suite. Some of the failing tests are ignored as they deal with validation of things like the Literal language string, which I am not sure OWLAPI needs to do as it is not an RDF framework.

## Further work

Further work would be needed on this branch to support RDF framework integration smoothly, e.g. as a special kind of OWLAPI `RDFConsumer` or `RDFRendererBase` that takes a Commons RDF [`Graph`](http://commonsrdf.incubator.apache.org/apidocs/org/apache/commons/rdf/api/Graph.html) instance instead of a file and format.

This integration could be taken further by removing some or all of the RDF* types in favour of the Commons RDF Simple implementation, like where there is no additional benefits given - however this would mean adding API changes from OWLAPI 4.


This patch highlights a few potential method renames in the OWLAPI to be directly compatible and avoid duplicate methods, however I have not suggested that as part of this patch as it is more drastic:

* RDFLiteral.getLexicalValue() -> getLexicalValue()
* RDFLiteral.getLang() -> getLanguageTag()
* IRI.toQuotedString() -> ntriplesString()

I also found that `RDFLiteral` deals with RDF 1.0 strings and uses `rdf:PlainLiteral` (RDF 1.1 merges plain literals to `xsd:string`) - I've tried to keep `rdf:PlainLiteral` support, but output both of those without `^^` type in the new `literal.ntriplesString()`, as Commons RDF follows RDF 1.1 specifications.  I also made the `rdf:langString` as a default type if a lang is given - but didn't force this as a type if BOTH lang and data type is given. (RDF 1.1 specs however says it must be `rdf:langString in this case) --- should this be raised as separate bugs?

There could be some potential bugs in OWLAPI highlighted in terms of equivalence, as OWLAPI BlankNodes can carry with them their local identifier, but that means that two such blank nodes from two different parser runs could potentially accidentally overlap if they were both added to a common Commons RDF `Graph` instance.
