### PR TITLE
RDF-1.1 and Sesame-4 targeted at OWLAPI-5

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -46,7 +46,15 @@ public class RDFLiteral extends RDFNode {
     public RDFLiteral(String literal, @Nullable String lang, @Nullable IRI datatype) {
         lexicalValue = checkNotNull(literal, "literal cannot be null");
         this.lang = lang == null ? "" : lang;
-        this.datatype = datatype == null ? OWL2Datatype.RDF_PLAIN_LITERAL.getIRI() : datatype;
+        if (lang == null || lang.isEmpty()) {
+            if (datatype == null) {
+               this.datatype = OWL2Datatype.XSD_STRING.getIRI();
+           } else {
+               this.datatype = datatype;
+           }
+        } else {
+            this.datatype = OWL2Datatype.RDF_LANG_STRING.getIRI();
+        }
     }
 
     /**
@@ -126,7 +134,7 @@ public class RDFLiteral extends RDFNode {
      * @return true if this literal has a non empty lang tag
      */
     public boolean hasLang() {
-        return !lang.isEmpty();
+        return lang != null && !lang.isEmpty();
     }
 
     /**

--- a/api/src/main/java/org/semanticweb/owlapi/util/SimpleRenderer.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/SimpleRenderer.java
@@ -20,6 +20,7 @@ import org.semanticweb.owlapi.formats.PrefixDocumentFormat;
 import org.semanticweb.owlapi.io.OWLObjectRenderer;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.model.parameters.Imports;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 /**
  * A simple renderer that can be used for debugging purposes and provide an
@@ -684,7 +685,7 @@ public class SimpleRenderer implements OWLObjectVisitor, OWLObjectRenderer {
     @Override
     public void visit(OWLLiteral node) {
         String literal = EscapeUtils.escapeString(node.getLiteral());
-        if (node.isRDFPlainLiteral()) {
+        if (node.isRDFPlainLiteral() || node.getDatatype().getIRI().equals(OWL2Datatype.RDF_LANG_STRING.getIRI())) {
             // We can use a syntactic shortcut
             sb.append('"').append(literal).append('"');
             if (node.hasLang()) {

--- a/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
+++ b/api/src/main/java/org/semanticweb/owlapi/vocab/OWL2Datatype.java
@@ -44,6 +44,7 @@ public enum OWL2Datatype implements HasIRI,HasShortForm,HasPrefixedName {
     /** RDF_XML_LITERAL. */          RDF_XML_LITERAL          (RDF,  "XMLLiteral",   Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"), 
     /** RDFS_LITERAL. */             RDFS_LITERAL             (RDFS, "Literal",      Category.CAT_UNIVERSAL,                   false, ".*"),
     /** RDF_PLAIN_LITERAL. */        RDF_PLAIN_LITERAL        (RDF,  "PlainLiteral", Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),
+    /** RDF_LANG_STRING */           RDF_LANG_STRING          (RDF,  "langString",   Category.CAT_STRING_WITH_LANGUAGE_TAG,    false, ".*"),
     /** OWL_REAL. */                 OWL_REAL                 (OWL,  "real",         Category.CAT_NUMBER,                      false, ".*"),
     /** OWL_RATIONAL. */             OWL_RATIONAL             (OWL,  "rational",     Category.CAT_NUMBER,                      false, "(\\+|-)?([0-9]+)(\\s)*(/)(\\s)*([0-9]+)"),
     /** XSD_STRING. */               XSD_STRING               (STRING,               Category.CAT_STRING_WITHOUT_LANGUAGE_TAG, false, ".*"),

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/OWLEntityCollectorTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/OWLEntityCollectorTestCase.java
@@ -137,7 +137,7 @@ public class OWLEntityCollectorTestCase {
         map.put(b.assD(),
                 "[<urn:test#i>, <urn:test#ann>, http://www.w3.org/2001/XMLSchema#boolean, http://www.w3.org/2001/XMLSchema#string, <urn:test#dp>]");
         map.put(b.assDPlain(),
-                "[<urn:test#i>, <urn:test#ann>, http://www.w3.org/2001/XMLSchema#string, http://www.w3.org/1999/02/22-rdf-syntax-ns#PlainLiteral, <urn:test#dp>]");
+                "[<urn:test#i>, <urn:test#ann>, http://www.w3.org/1999/02/22-rdf-syntax-ns#langString, http://www.w3.org/2001/XMLSchema#string, <urn:test#dp>]");
         map.put(b.dDom(), "[<urn:test#ann>, http://www.w3.org/2001/XMLSchema#string, <urn:test#c>, <urn:test#dp>]");
         Collection<Object[]> toReturn = new ArrayList<>();
         map.forEach((k, v) -> toReturn.add(new Object[] { k, v }));

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/OWLObjectComponentCollectorTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/OWLObjectComponentCollectorTestCase.java
@@ -272,6 +272,9 @@ public class OWLObjectComponentCollectorTestCase {
         OWLObjectComponentCollector testsubject = new OWLObjectComponentCollector();
         Set<OWLObject> components = testsubject.getComponents(object);
         Set<String> strings = asSet(components.stream().map(c -> c.toString()));
+        if(!expected.equals(strings)) {
+            System.out.println("Failed comparison for object: " + object);
+        }
         assertEquals(expected, strings);
     }
 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -15,9 +15,18 @@ package org.semanticweb.owlapi.api.test.literals;
 import static org.junit.Assert.*;
 import static org.semanticweb.owlapi.apibinding.OWLFunctionalSyntaxFactory.*;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+
 import org.junit.Test;
 import org.semanticweb.owlapi.api.test.baseclasses.TestBase;
 import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
+import org.semanticweb.owlapi.model.OWLAnnotationProperty;
+import org.semanticweb.owlapi.model.OWLAxiom;
+import org.semanticweb.owlapi.model.OWLClass;
 import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
@@ -29,33 +38,7 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
  * @since 3.1.0
  */
 @SuppressWarnings("javadoc")
-public class LiteralTestCase extends AbstractAxiomsRoundTrippingTestCase {
-
-    @Nonnull
-    @Override
-    protected Set<? extends OWLAxiom> createAxioms() {
-        OWLLiteral literalWithLang = Literal("abc", "en");
-        OWLLiteral literalWithoutLang = Literal("abcd", "");
-        OWLLiteral literalPlain = Literal("abcde");
-        OWLLiteral literalString = Literal("abcdef", OWL2Datatype.XSD_STRING);
-        OWLClass cls = Class(iri("A"));
-        OWLAnnotationProperty prop = AnnotationProperty(iri("prop"));
-        OWLAnnotationAssertionAxiom ax1 = AnnotationAssertion(prop,
-                cls.getIRI(), literalWithLang);
-        OWLAnnotationAssertionAxiom ax2 = AnnotationAssertion(prop,
-                cls.getIRI(), literalWithoutLang);
-        OWLAnnotationAssertionAxiom ax3 = AnnotationAssertion(prop,
-                cls.getIRI(), literalPlain);
-        OWLAnnotationAssertionAxiom ax4 = AnnotationAssertion(prop,
-                cls.getIRI(), literalString);
-        Set<OWLAxiom> axioms = new HashSet<>();
-        axioms.add(ax1);
-        axioms.add(ax2);
-        axioms.add(ax3);
-        axioms.add(ax4);
-        axioms.add(Declaration(cls));
-        return axioms;
-    }
+public class LiteralTestCase extends TestBase {
 
     @Test
     public void testHasLangMethod() {

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -29,7 +29,33 @@ import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
  * @since 3.1.0
  */
 @SuppressWarnings("javadoc")
-public class LiteralTestCase extends TestBase {
+public class LiteralTestCase extends AbstractAxiomsRoundTrippingTestCase {
+
+    @Nonnull
+    @Override
+    protected Set<? extends OWLAxiom> createAxioms() {
+        OWLLiteral literalWithLang = Literal("abc", "en");
+        OWLLiteral literalWithoutLang = Literal("abcd", "");
+        OWLLiteral literalPlain = Literal("abcde");
+        OWLLiteral literalString = Literal("abcdef", OWL2Datatype.XSD_STRING);
+        OWLClass cls = Class(iri("A"));
+        OWLAnnotationProperty prop = AnnotationProperty(iri("prop"));
+        OWLAnnotationAssertionAxiom ax1 = AnnotationAssertion(prop,
+                cls.getIRI(), literalWithLang);
+        OWLAnnotationAssertionAxiom ax2 = AnnotationAssertion(prop,
+                cls.getIRI(), literalWithoutLang);
+        OWLAnnotationAssertionAxiom ax3 = AnnotationAssertion(prop,
+                cls.getIRI(), literalPlain);
+        OWLAnnotationAssertionAxiom ax4 = AnnotationAssertion(prop,
+                cls.getIRI(), literalString);
+        Set<OWLAxiom> axioms = new HashSet<>();
+        axioms.add(ax1);
+        axioms.add(ax2);
+        axioms.add(ax3);
+        axioms.add(ax4);
+        axioms.add(Declaration(cls));
+        return axioms;
+    }
 
     @Test
     public void testHasLangMethod() {
@@ -60,30 +86,36 @@ public class LiteralTestCase extends TestBase {
         assertFalse(literalWithLang.getDatatype().getIRI().isPlainLiteral());
         assertFalse(literalWithLang.isRDFPlainLiteral());
         assertTrue(literalWithLang.hasLang());
+        assertEquals("en", literalWithLang.getLang());
+        assertEquals(literalWithLang.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     @Test
     public void testPlainLiteralWithEmbeddedLang() {
         OWLLiteral literal = Literal("abc@en", PlainLiteral());
         assertTrue(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("en", literal.getLang());
         assertEquals("abc", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     public void tesPlainLiteralWithEmbeddedEmptyLang() {
         OWLLiteral literal = Literal("abc@", PlainLiteral());
         assertFalse(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("", literal.getLang());
         assertEquals("abc", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.XSD_STRING.getDatatype(df));
     }
 
     public void tesPlainLiteralWithDoubleSep() {
         OWLLiteral literal = Literal("abc@@en", PlainLiteral());
+        assertTrue(literal.hasLang());
+        assertFalse(literal.isRDFPlainLiteral());
         assertEquals("en", literal.getLang());
         assertEquals("abc@", literal.getLiteral());
-        assertEquals(literal.getDatatype(), PlainLiteral());
+        assertEquals(literal.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
     }
 
     @Test

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -57,8 +57,9 @@ public class LiteralTestCase extends TestBase {
     @Test
     public void testPlainLiteralWithLang() {
         OWLLiteral literalWithLang = Literal("abc", "en");
-        assertTrue(literalWithLang.getDatatype().getIRI().isPlainLiteral());
-        assertTrue(literalWithLang.isRDFPlainLiteral());
+        assertFalse(literalWithLang.getDatatype().getIRI().isPlainLiteral());
+        assertFalse(literalWithLang.isRDFPlainLiteral());
+        assertTrue(literalWithLang.hasLang());
     }
 
     @Test

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
@@ -64,8 +64,10 @@ public class TestPlainLiteralTestCase extends TestBase {
         o.add(df.getOWLDataPropertyAssertionAxiom(p, i, l));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         o.saveOntology(out);
-        String expected = "<test:p rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</test:p>";
-        assertTrue(out.toString(), out.toString().contains(expected));
+        String expectedStart = "<test:p";
+        String expectedEnd = ">test</test:p>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 
     @Test
@@ -74,8 +76,10 @@ public class TestPlainLiteralTestCase extends TestBase {
         OWLIndividual i = df.getOWLNamedIndividual("urn:test#ind");
         OWLLiteral l = df.getOWLLiteral("test", OWL2Datatype.RDF_PLAIN_LITERAL);
         o.add(df.getOWLAnnotationAssertionAxiom(df.getRDFSComment(), i.asOWLNamedIndividual().getIRI(), l));
-        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
-        assertTrue(saveOntology(o).toString().contains(expected));
+        String expectedStart = "<rdfs:comment";
+   		String expectedEnd = ">test</rdfs:comment>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 
     @Test
@@ -86,7 +90,9 @@ public class TestPlainLiteralTestCase extends TestBase {
         o.applyChange(new AddOntologyAnnotation(o, a));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         o.saveOntology(out);
-        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
-        assertTrue(out.toString(), out.toString().contains(expected));
+        String expectedStart = "<rdfs:comment";
+        String expectedEnd = ">test</rdfs:comment>";
+        assertTrue(out.toString(), out.toString().contains(expectedStart));
+        assertTrue(out.toString(), out.toString().contains(expectedEnd));
     }
 }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
@@ -76,6 +76,8 @@ public class TestPlainLiteralTestCase extends TestBase {
         OWLIndividual i = df.getOWLNamedIndividual("urn:test#ind");
         OWLLiteral l = df.getOWLLiteral("test", OWL2Datatype.RDF_PLAIN_LITERAL);
         o.add(df.getOWLAnnotationAssertionAxiom(df.getRDFSComment(), i.asOWLNamedIndividual().getIRI(), l));
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        o.saveOntology(out);
         String expectedStart = "<rdfs:comment";
    		String expectedEnd = ">test</rdfs:comment>";
         assertTrue(out.toString(), out.toString().contains(expectedStart));

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestPlainLiteralTestCase.java
@@ -64,7 +64,7 @@ public class TestPlainLiteralTestCase extends TestBase {
         o.add(df.getOWLDataPropertyAssertionAxiom(p, i, l));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         o.saveOntology(out);
-        String expected = "<test:p>test</test:p>";
+        String expected = "<test:p rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</test:p>";
         assertTrue(out.toString(), out.toString().contains(expected));
     }
 
@@ -74,7 +74,7 @@ public class TestPlainLiteralTestCase extends TestBase {
         OWLIndividual i = df.getOWLNamedIndividual("urn:test#ind");
         OWLLiteral l = df.getOWLLiteral("test", OWL2Datatype.RDF_PLAIN_LITERAL);
         o.add(df.getOWLAnnotationAssertionAxiom(df.getRDFSComment(), i.asOWLNamedIndividual().getIRI(), l));
-        String expected = "<rdfs:comment>test</rdfs:comment>";
+        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
         assertTrue(saveOntology(o).toString().contains(expected));
     }
 
@@ -86,7 +86,7 @@ public class TestPlainLiteralTestCase extends TestBase {
         o.applyChange(new AddOntologyAnnotation(o, a));
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         o.saveOntology(out);
-        String expected = "<rdfs:comment>test</rdfs:comment>";
+        String expected = "<rdfs:comment rdf:datatype=\"http://www.w3.org/2001/XMLSchema#string\">test</rdfs:comment>";
         assertTrue(out.toString(), out.toString().contains(expected));
     }
 }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalizedEntities.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/InternalizedEntities.java
@@ -30,6 +30,7 @@ public class InternalizedEntities {
     protected static final @Nonnull OWLDataProperty         OWL_TOP_DATA_PROPERTY       = new OWLDataPropertyImpl           (OWLRDFVocabulary.OWL_TOP_DATA_PROPERTY.getIRI());
     protected static final @Nonnull OWLDataProperty         OWL_BOTTOM_DATA_PROPERTY    = new OWLDataPropertyImpl           (OWLRDFVocabulary.OWL_BOTTOM_DATA_PROPERTY.getIRI());
     protected static final @Nonnull OWLDatatype             PLAIN                       = new OWL2DatatypeImpl              (RDF_PLAIN_LITERAL);
+    protected static final @Nonnull OWLDatatype             LANGSTRING                       = new OWL2DatatypeImpl              (RDF_LANG_STRING);
     protected static final @Nonnull OWLDatatype             XSDBOOLEAN                  = new OWL2DatatypeImpl              (XSD_BOOLEAN);
     protected static final @Nonnull OWLDatatype             XSDDOUBLE                   = new OWL2DatatypeImpl              (XSD_DOUBLE);
     protected static final @Nonnull OWLDatatype             XSDFLOAT                    = new OWL2DatatypeImpl              (XSD_FLOAT);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
@@ -31,6 +31,25 @@ import org.semanticweb.owlapi.vocab.XSDVocabulary;
  */
 public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInternals, Serializable {
 
+    private static final @Nonnull OWLDatatype PLAIN = new OWL2DatatypeImpl(
+            RDF_PLAIN_LITERAL);
+    private static final @Nonnull OWLDatatype LANGSTRING = new OWL2DatatypeImpl(
+            RDF_LANG_STRING);
+    private static final @Nonnull OWLDatatype XSDBOOLEAN = new OWL2DatatypeImpl(
+            XSD_BOOLEAN);
+    private static final @Nonnull OWLDatatype XSDDOUBLE = new OWL2DatatypeImpl(
+            XSD_DOUBLE);
+    private static final @Nonnull OWLDatatype XSDFLOAT = new OWL2DatatypeImpl(XSD_FLOAT);
+    private static final @Nonnull OWLDatatype XSDINTEGER = new OWL2DatatypeImpl(
+            XSD_INTEGER);
+    private static final @Nonnull OWLDatatype XSDSTRING = new OWL2DatatypeImpl(
+            XSD_STRING);
+    private static final @Nonnull OWLDatatype RDFSLITERAL = new OWL2DatatypeImpl(
+            RDFS_LITERAL);
+    private static final @Nonnull OWLLiteral trueLiteral = new OWLLiteralImplBoolean(
+            true, XSDBOOLEAN);
+    private static final @Nonnull OWLLiteral falseLiteral = new OWLLiteralImplBoolean(
+            false, XSDBOOLEAN);
     private @Nullable OWLLiteral negativeFloatZero;
     private final boolean useCompression;
 
@@ -120,14 +139,14 @@ public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInterna
     @Override
     public OWLLiteral getOWLLiteral(String lexicalValue, OWLDatatype datatype) {
         OWLLiteral literal = null;
-        if (datatype.isRDFPlainLiteral()) {
+        if (datatype.isRDFPlainLiteral() || datatype.equals(LANGSTRING)) {
             int sep = lexicalValue.lastIndexOf('@');
             if (sep != -1) {
                 String lex = lexicalValue.substring(0, sep);
                 String lang = lexicalValue.substring(sep + 1);
-                literal = getBasicLiteral(lex, lang, PLAIN);
+                literal = getBasicLiteral(lex, lang, LANGSTRING);
             } else {
-                literal = getBasicLiteral(lexicalValue, datatype);
+                literal = getBasicLiteral(lexicalValue, XSDSTRING);
             }
         } else {
             // check the special cases
@@ -187,7 +206,7 @@ public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInterna
     protected OWLLiteral getBasicLiteral(String lexicalValue, String lang, @Nullable OWLDatatype datatype) {
         OWLLiteral literal = null;
         if (useCompression) {
-            if (datatype == null || datatype.isRDFPlainLiteral()) {
+            if (datatype == null || datatype.isRDFPlainLiteral() || datatype.equals(RDF_LANG_STRING)) {
                 literal = new OWLLiteralImplPlain(lexicalValue, lang);
             } else {
                 literal = new OWLLiteralImpl(lexicalValue, lang, datatype);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
@@ -19,10 +19,10 @@ import java.io.Serializable;
 import java.util.Locale;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import org.semanticweb.owlapi.model.*;
-import org.semanticweb.owlapi.vocab.XSDVocabulary;
 
 /**
  * No cache used.
@@ -31,25 +31,6 @@ import org.semanticweb.owlapi.vocab.XSDVocabulary;
  */
 public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInternals, Serializable {
 
-    private static final @Nonnull OWLDatatype PLAIN = new OWL2DatatypeImpl(
-            RDF_PLAIN_LITERAL);
-    private static final @Nonnull OWLDatatype LANGSTRING = new OWL2DatatypeImpl(
-            RDF_LANG_STRING);
-    private static final @Nonnull OWLDatatype XSDBOOLEAN = new OWL2DatatypeImpl(
-            XSD_BOOLEAN);
-    private static final @Nonnull OWLDatatype XSDDOUBLE = new OWL2DatatypeImpl(
-            XSD_DOUBLE);
-    private static final @Nonnull OWLDatatype XSDFLOAT = new OWL2DatatypeImpl(XSD_FLOAT);
-    private static final @Nonnull OWLDatatype XSDINTEGER = new OWL2DatatypeImpl(
-            XSD_INTEGER);
-    private static final @Nonnull OWLDatatype XSDSTRING = new OWL2DatatypeImpl(
-            XSD_STRING);
-    private static final @Nonnull OWLDatatype RDFSLITERAL = new OWL2DatatypeImpl(
-            RDFS_LITERAL);
-    private static final @Nonnull OWLLiteral trueLiteral = new OWLLiteralImplBoolean(
-            true, XSDBOOLEAN);
-    private static final @Nonnull OWLLiteral falseLiteral = new OWLLiteralImplBoolean(
-            false, XSDBOOLEAN);
     private @Nullable OWLLiteral negativeFloatZero;
     private final boolean useCompression;
 
@@ -213,7 +194,7 @@ public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInterna
     protected OWLLiteral getBasicLiteral(String lexicalValue, String lang, @Nullable OWLDatatype datatype) {
         OWLLiteral literal = null;
         if (useCompression) {
-            if (datatype == null || datatype.isRDFPlainLiteral() || datatype.equals(RDF_LANG_STRING)) {
+            if (datatype == null || datatype.isRDFPlainLiteral() || datatype.equals(LANGSTRING)) {
                 literal = new OWLLiteralImplPlain(lexicalValue, lang);
             } else {
                 literal = new OWLLiteralImpl(lexicalValue, lang, datatype);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryInternalsImplNoCache.java
@@ -102,7 +102,7 @@ public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInterna
     @Override
     public OWLLiteral getOWLLiteral(String value) {
         if (useCompression) {
-            return new OWLLiteralImpl(value, "", getOWLDatatype(XSDVocabulary.STRING.getIRI()));
+            return new OWLLiteralImpl(value, "", XSDSTRING);
         }
         return new OWLLiteralImplString(value);
     }
@@ -115,10 +115,17 @@ public class OWLDataFactoryInternalsImplNoCache implements OWLDataFactoryInterna
         } else {
             normalisedLang = lang.trim().toLowerCase(Locale.ENGLISH);
         }
-        if (useCompression) {
-            return new OWLLiteralImpl(literal, normalisedLang, null);
+        if (normalisedLang.isEmpty()) {
+            if (useCompression) {
+                return new OWLLiteralImpl(literal, null, XSDSTRING);
+            }
+            return new OWLLiteralImplString(literal);
+        } else {
+            if (useCompression) {
+                return new OWLLiteralImpl(literal, normalisedLang, null);
+            }
+            return new OWLLiteralImplPlain(literal, normalisedLang);
         }
-        return new OWLLiteralImplPlain(literal, normalisedLang);
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -42,6 +42,8 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
     private static final int COMPRESSION_LIMIT = 160;
     private final LiteralWrapper literal;
     private static final @Nonnull OWLDatatype RDF_PLAIN_LITERAL = new OWL2DatatypeImpl(OWL2Datatype.RDF_PLAIN_LITERAL);
+    private static final @Nonnull OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(OWL2Datatype.RDF_LANG_STRING);
+    private static final @Nonnull OWLDatatype XSD_STRING = new OWL2DatatypeImpl(OWL2Datatype.XSD_STRING);
     private final @Nonnull OWLDatatype datatype;
     private final @Nonnull String language;
     private final int hashcode;
@@ -66,7 +68,7 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
         if (lang == null || lang.isEmpty()) {
             language = "";
             if (datatype == null) {
-                this.datatype = RDF_PLAIN_LITERAL;
+                this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
@@ -78,7 +80,7 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
                         "Error: cannot build a literal with type: " + datatype.getIRI() + " and language: " + lang);
             }
             language = lang;
-            this.datatype = RDF_PLAIN_LITERAL;
+            this.datatype = RDF_LANG_STRING;
         }
         hashcode = getHashCode();
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -67,15 +67,15 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
         this.literal = new LiteralWrapper(checkNotNull(literal, "literal cannot be null"));
         if (lang == null || lang.isEmpty()) {
             language = "";
-            if (datatype == null) {
+            if (datatype == null || datatype.equals(RDF_PLAIN_LITERAL) || datatype.equals(XSD_STRING)) {
                 this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
         } else {
-            if (datatype != null && !datatype.isRDFPlainLiteral()) {
+            if (datatype != null && !(datatype.equals(RDF_LANG_STRING) || datatype.equals(RDF_PLAIN_LITERAL))) {
                 // ERROR: attempting to build a literal with a language tag and
-                // type different from plain literal
+                // type different from plain literal or lang string
                 throw new OWLRuntimeException(
                         "Error: cannot build a literal with type: " + datatype.getIRI() + " and language: " + lang);
             }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
@@ -30,9 +30,12 @@ import org.semanticweb.owlapi.vocab.OWL2Datatype;
 public class OWLLiteralImplNoCompression extends OWLObjectImpl implements OWLLiteral {
 
     private static final @Nonnull OWLDatatype RDF_PLAIN_LITERAL = new OWL2DatatypeImpl(OWL2Datatype.RDF_PLAIN_LITERAL);
+    private static final @Nonnull OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(OWL2Datatype.RDF_LANG_STRING);
+    private static final @Nonnull OWLDatatype XSD_STRING = new OWL2DatatypeImpl(OWL2Datatype.XSD_STRING);
     private final @Nonnull String literal;
     private final @Nonnull OWLDatatype datatype;
     private final @Nonnull String language;
+    private final int hashcode;
 
     @Override
     protected int index() {
@@ -52,19 +55,19 @@ public class OWLLiteralImplNoCompression extends OWLObjectImpl implements OWLLit
         if (lang == null || lang.isEmpty()) {
             language = "";
             if (datatype == null) {
-                this.datatype = RDF_PLAIN_LITERAL;
+                this.datatype = XSD_STRING;
             } else {
                 this.datatype = datatype;
             }
         } else {
-            if (datatype != null && !datatype.isRDFPlainLiteral()) {
+            if (datatype != null && !(datatype.equals(RDF_LANG_STRING) || datatype.equals(RDF_PLAIN_LITERAL))) {
                 // ERROR: attempting to build a literal with a language tag and
-                // type different from plain literal
+                // type different from RDF_LANG_STRING or RDF_PLAIN_LITERAL
                 throw new OWLRuntimeException(
                         "Error: cannot build a literal with type: " + datatype.getIRI() + " and language: " + lang);
             }
             language = lang;
-            this.datatype = RDF_PLAIN_LITERAL;
+            this.datatype = RDF_LANG_STRING;
         }
         hashCode = getHashCode();
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
@@ -35,7 +35,6 @@ public class OWLLiteralImplNoCompression extends OWLObjectImpl implements OWLLit
     private final @Nonnull String literal;
     private final @Nonnull OWLDatatype datatype;
     private final @Nonnull String language;
-    private final int hashcode;
 
     @Override
     protected int index() {

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -43,11 +43,11 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
      */
     public OWLLiteralImplPlain(String literal, @Nullable String lang) {
         this.literal = literal;
-        if (lang == null || lang.length() == 0) {
+        if (lang == null || lang.isEmpty()) {
             this.lang = "";
             this.datatype = XSD_STRING;
         } else {
-            this.lang = lang;
+            this.lang = lang.trim();
             this.datatype = RDF_LANG_STRING;
         }
         hashCode = getHashCode();
@@ -65,7 +65,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public boolean hasLang() {
-        return !lang.equals("");
+        return !lang.isEmpty();
     }
 
     @Override
@@ -128,19 +128,19 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
-        }
-        if (!super.equals(obj)) {
-            return false;
-        }
-        if (!(obj instanceof OWLLiteral)) {
-            return false;
-        }
-        OWLLiteral other = (OWLLiteral) obj;
-        if (other instanceof OWLLiteralImplPlain) {
-            return literal.equals(((OWLLiteralImplPlain) other).literal) && lang.equals(other.getLang());
-        }
-        return getLiteral().equals(other.getLiteral()) && getDatatype().equals(other.getDatatype())
+        if (super.equals(obj)) {
+            if (!(obj instanceof OWLLiteral)) {
+                return false;
+            }
+            OWLLiteral other = (OWLLiteral) obj;
+            if (other instanceof OWLLiteralImplPlain) {
+                return literal.equals(((OWLLiteralImplPlain) other).literal) && lang.equals(other.getLang());
+            }
+            return getLiteral().equals(other.getLiteral()) && getDatatype().equals(other.getDatatype())
                 && lang.equals(other.getLang());
+        }
+
+        return false;
     }
 
     @Override
@@ -150,10 +150,10 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
         if (diff != 0) {
             return diff;
         }
-        diff = getDatatype().compareTo(other.getDatatype());
-        if (diff != 0) {
+        diff = lang.compareToIgnoreCase(other.getLang());
+        if(diff != 0) {
             return diff;
         }
-        return lang.compareTo(other.getLang());
+        return getDatatype().compareTo(other.getDatatype());
     }
 }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -21,7 +21,7 @@ import org.semanticweb.owlapi.model.OWLObject;
 import org.semanticweb.owlapi.util.OWLObjectTypeIndexProvider;
 
 /**
- * An OWLLiteral whose datatype is RDF_PLAIN_LITERAL.
+ * An OWLLiteral whose datatype is RDF_LANG_STRING or XSD_STRING
  * 
  * @author Matthew Horridge, The University Of Manchester, Bio-Health
  *         Informatics Group, Date: 26-Oct-2006
@@ -29,7 +29,11 @@ import org.semanticweb.owlapi.util.OWLObjectTypeIndexProvider;
 public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     private final @Nonnull String literal;
+    private final @Nonnull OWLDatatype datatype;
     private final @Nonnull String lang;
+    private final int hashcode;
+    private static final OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(OWL2Datatype.RDF_LANG_STRING);
+    private static final OWLDatatype XSD_STRING = new OWL2DatatypeImpl(OWL2Datatype.XSD_STRING);
 
     /**
      * @param literal
@@ -41,8 +45,10 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
         this.literal = literal;
         if (lang == null || lang.length() == 0) {
             this.lang = "";
+            this.datatype = XSD_STRING;
         } else {
             this.lang = lang;
+            this.datatype = RDF_LANG_STRING;
         }
         hashCode = getHashCode();
     }
@@ -64,7 +70,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public boolean isRDFPlainLiteral() {
-        return true;
+        return false;
     }
 
     @Override
@@ -82,7 +88,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
 
     @Override
     public OWLDatatype getDatatype() {
-        return InternalizedEntities.PLAIN;
+        return this.datatype;
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -31,9 +31,6 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
     private final @Nonnull String literal;
     private final @Nonnull OWLDatatype datatype;
     private final @Nonnull String lang;
-    private final int hashcode;
-    private static final OWLDatatype RDF_LANG_STRING = new OWL2DatatypeImpl(OWL2Datatype.RDF_LANG_STRING);
-    private static final OWLDatatype XSD_STRING = new OWL2DatatypeImpl(OWL2Datatype.XSD_STRING);
 
     /**
      * @param literal
@@ -45,10 +42,10 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
         this.literal = literal;
         if (lang == null || lang.isEmpty()) {
             this.lang = "";
-            this.datatype = XSD_STRING;
+            this.datatype = InternalizedEntities.XSDSTRING;
         } else {
             this.lang = lang.trim();
-            this.datatype = RDF_LANG_STRING;
+            this.datatype = InternalizedEntities.LANGSTRING;
         }
         hashCode = getHashCode();
     }
@@ -128,6 +125,7 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
     public boolean equals(@Nullable Object obj) {
         if (this == obj) {
             return true;
+        }
         if (super.equals(obj)) {
             if (!(obj instanceof OWLLiteral)) {
                 return false;

--- a/parsers/src/main/java/org/semanticweb/owlapi/owlxml/parser/PARSER_OWLXMLVocabulary.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/owlxml/parser/PARSER_OWLXMLVocabulary.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.util.RemappingIndividualProvider;
 import org.semanticweb.owlapi.vocab.Namespaces;
+import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import org.semanticweb.owlapi.vocab.OWLFacet;
 import org.semanticweb.owlapi.vocab.OWLXMLVocabulary;
 
@@ -2067,8 +2068,9 @@ class OWLLiteralElementHandler extends OWLElementHandler<OWLLiteral> {
 
     @Override
     void endElement() {
-        if (iri != null && !iri.isPlainLiteral()) {
-            literal = df.getOWLLiteral(getText(), df.getOWLDatatype(verifyNotNull(iri)));
+        if (iri != null && !(iri.isPlainLiteral() || iri.equals(OWL2Datatype.RDF_LANG_STRING.getIRI()))) {
+            literal = df.getOWLLiteral(getText(),
+                    df.getOWLDatatype(verifyNotNull(iri)));
         } else {
             literal = df.getOWLLiteral(getText(), lang);
         }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -1389,12 +1389,12 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker, Anonym
      */
     OWLLiteral getOWLLiteral(String literal, @Nullable IRI datatype, @Nullable String lang) {
         if (lang != null && !lang.trim().isEmpty()) {
-            return dataFactory.getOWLLiteral(literal, lang);
+            return df.getOWLLiteral(literal, lang);
         } else if (datatype != null) {
-            return dataFactory.getOWLLiteral(literal,
-                    dataFactory.getOWLDatatype(datatype));
+            return df.getOWLLiteral(literal,
+                    df.getOWLDatatype(datatype));
         } else {
-            return dataFactory.getOWLLiteral(literal);
+            return df.getOWLLiteral(literal);
         }
     }
 

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -1388,10 +1388,14 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker, Anonym
      *         params)
      */
     OWLLiteral getOWLLiteral(String literal, @Nullable IRI datatype, @Nullable String lang) {
-        if (datatype == null) {
-            return df.getOWLLiteral(literal, lang);
+        if (lang != null && !lang.trim().isEmpty()) {
+            return dataFactory.getOWLLiteral(literal, lang);
+        } else if (datatype != null) {
+            return dataFactory.getOWLLiteral(literal,
+                    dataFactory.getOWLDatatype(datatype));
+        } else {
+            return dataFactory.getOWLLiteral(literal);
         }
-        return df.getOWLLiteral(literal, df.getOWLDatatype(datatype));
     }
 
     /**

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
@@ -231,12 +231,12 @@ public class RDFXMLRenderer extends RDFRendererBase {
                 }
             } else {
                 RDFLiteral rdfLiteralNode = (RDFLiteral) objectNode;
-                if (!rdfLiteralNode.isPlainLiteral()) {
-                    writer.writeDatatypeAttribute(rdfLiteralNode.getDatatype());
-                } else if (rdfLiteralNode.hasLang()) {
+                if (rdfLiteralNode.hasLang()) {
                     writer.writeLangAttribute(rdfLiteralNode.getLang());
+                } else if (!rdfLiteralNode.isPlainLiteral()) {
+                    writer.writeDatatypeAttribute(rdfLiteralNode.getDatatype());
                 }
-                writer.writeTextContent(rdfLiteralNode.getLexicalValue());
+               	writer.writeTextContent(rdfLiteralNode.getLexicalValue());
             }
             writer.writeEndElement();
         }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
@@ -198,8 +198,13 @@ public class TurtleRenderer extends RDFRendererBase {
                 write(node.getLexicalValue());
             } else {
                 writeStringLiteral(node.getLexicalValue());
-                write("^^");
-                write(node.getDatatype());
+                if (node.hasLang()) {
+                    write("@");
+                    write(node.getLang());
+                } else {
+	                write("^^");
+	                write(node.getDatatype());
+                }
             }
         } else {
             writeStringLiteral(node.getLexicalValue());

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	<properties>
 		<!-- Specify the encoding of the source files. -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<sesame.version>2.7.12</sesame.version>
+		<sesame.version>4.0.0</sesame.version>
 		<!-- remove this line for releases, if the release process fails because of missing javadoc jars -->
 		<no-javadoc>true</no-javadoc>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -137,17 +137,17 @@
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>
-				<version>2.5.1</version>
+				<version>2.6.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-databind</artifactId>
-				<version>2.5.1</version>
+				<version>2.6.3</version>
 			</dependency>
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-annotations</artifactId>
-				<version>2.5.1</version>
+				<version>2.6.3</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -88,39 +88,14 @@
 			<version>${inherited.sesame.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.github.jsonld-java</groupId>
-			<artifactId>jsonld-java-sesame</artifactId>
-			<version>0.5.0</version>
+			<groupId>org.openrdf.sesame</groupId>
+			<artifactId>sesame-rio-jsonld</artifactId>
+			<version>${inherited.sesame.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.semarglproject</groupId>
-			<artifactId>semargl-sesame</artifactId>
-			<version>0.6.1</version>
+			<groupId>com.github.jsonld-java</groupId>
+			<artifactId>jsonld-java</artifactId>
+			<version>0.7.0</version>
 		</dependency>
 	</dependencies>
-	
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-core</artifactId>
-				<version>2.5.1</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-databind</artifactId>
-				<version>2.5.1</version>
-			</dependency>
-			<dependency>
-				<groupId>com.fasterxml.jackson.core</groupId>
-				<artifactId>jackson-annotations</artifactId>
-				<version>2.5.1</version>
-			</dependency>
-			<dependency>
-				<groupId>org.openrdf.sesame</groupId>
-				<artifactId>sesame-bom</artifactId>
-				<version>${inherited.sesame.version}</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
@@ -37,6 +37,8 @@ package org.semanticweb.owlapi.rio;
 
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.*;
 
+import java.util.Optional;
+
 import javax.annotation.Nullable;
 
 import org.openrdf.model.BNode;
@@ -127,7 +129,7 @@ public class RioOWLRDFConsumerAdapter extends OWLRDFConsumer implements RDFHandl
         } else {
             final Literal literalObject = (Literal) st.getObject();
             String literalDatatype = null;
-            final String literalLanguage = literalObject.getLanguage();
+            final String literalLanguage = literalObject.getLanguage().orElse(null);
             if (literalLanguage == null) {
                 literalDatatype = literalObject.getDatatype().stringValue();
             }

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioOWLRDFConsumerAdapter.java
@@ -128,9 +128,7 @@ public class RioOWLRDFConsumerAdapter extends OWLRDFConsumer implements RDFHandl
             final Literal literalObject = (Literal) st.getObject();
             String literalDatatype = null;
             final String literalLanguage = literalObject.getLanguage();
-            // TODO: When updating to Sesame-2.8 with RDF-1.1 support, the
-            // following if condition will always be true
-            if (literalObject.getDatatype() != null) {
+            if (literalLanguage == null) {
                 literalDatatype = literalObject.getDatatype().stringValue();
             }
             LOGGER.trace("statement with literal value");

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
@@ -94,13 +94,13 @@ public final class RioUtils {
      */
     public static Collection<Statement> tripleAsStatements(final RDFTriple triple, final Resource... contexts) {
         OpenRDFUtil.verifyContextNotNull(contexts);
-        final ValueFactoryImpl vf = ValueFactoryImpl.getInstance();
+        final ValueFactory vf = SimpleValueFactory.getInstance();
         Resource subject;
-        URI predicate;
+        org.openrdf.model.IRI predicate;
         Value object;
         if (triple.getSubject() instanceof RDFResourceIRI) {
             try {
-                subject = vf.createURI(triple.getSubject().getIRI().toString());
+                subject = vf.createIRI(triple.getSubject().getIRI().toString());
             } catch (@SuppressWarnings("unused") IllegalArgumentException iae) {
                 LOGGER.error("Subject URI was invalid: {}", triple);
                 return Collections.emptyList();
@@ -111,14 +111,14 @@ public final class RioUtils {
             subject = node(triple.getSubject(), vf);
         }
         try {
-            predicate = vf.createURI(triple.getPredicate().getIRI().toString());
+            predicate = vf.createIRI(triple.getPredicate().getIRI().toString());
         } catch (@SuppressWarnings("unused") IllegalArgumentException iae) {
             LOGGER.error("Predicate URI was invalid: {}", triple);
             return Collections.emptyList();
         }
         if (triple.getObject() instanceof RDFResourceIRI) {
             try {
-                object = vf.createURI(triple.getObject().getIRI().toString());
+                object = vf.createIRI(triple.getObject().getIRI().toString());
             } catch (@SuppressWarnings("unused") IllegalArgumentException iae) {
                 LOGGER.error("Object URI was invalid: {}", triple);
                 return Collections.emptyList();
@@ -155,7 +155,7 @@ public final class RioUtils {
                     XMLSchema.STRING);
         } else {
             object = vf.createLiteral(literalObject.getLexicalValue(),
-                    vf.createURI(literalObject.getDatatype().toString()));
+                    vf.createIRI(literalObject.getDatatype().toString()));
         }
         return object;
     }
@@ -167,7 +167,7 @@ public final class RioUtils {
      *        value factory
      * @return blank node
      */
-    protected static BNode node(final RDFNode node, final ValueFactoryImpl vf) {
+    protected static BNode node(final RDFNode node, final ValueFactory vf) {
         if (node.getIRI().getNamespace().startsWith("_:")) {
             return vf.createBNode(node.getIRI().toString().substring(2));
         }

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
@@ -49,7 +49,9 @@ import org.openrdf.model.Resource;
 import org.openrdf.model.Statement;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
-import org.openrdf.model.impl.ValueFactoryImpl;
+import org.openrdf.model.ValueFactory;
+import org.openrdf.model.impl.SimpleValueFactory;
+import org.openrdf.model.vocabulary.XMLSchema;
 import org.semanticweb.owlapi.io.RDFLiteral;
 import org.semanticweb.owlapi.io.RDFNode;
 import org.semanticweb.owlapi.io.RDFResourceIRI;
@@ -143,16 +145,14 @@ public final class RioUtils {
      *        literal
      * @return value
      */
-    protected static Value literal(final ValueFactoryImpl vf, final RDFLiteral literalObject) {
+    protected static Value literal(final ValueFactory vf, final RDFLiteral literalObject) {
         Value object;
-        // TODO: When updating to Sesame-2.8 the following may need to be
-        // rewritten
-        if (literalObject.isPlainLiteral()) {
-            if (literalObject.hasLang()) {
-                object = vf.createLiteral(literalObject.getLexicalValue(), literalObject.getLang());
-            } else {
-                object = vf.createLiteral(literalObject.getLexicalValue());
-            }
+        if (literalObject.hasLang()) {
+            object = vf.createLiteral(literalObject.getLexicalValue(),
+                    literalObject.getLang());
+        } else if (literalObject.getDatatype() == null) {
+            object = vf.createLiteral(literalObject.getLexicalValue(),
+                    XMLSchema.STRING);
         } else {
             object = vf.createLiteral(literalObject.getLexicalValue(),
                     vf.createURI(literalObject.getDatatype().toString()));


### PR DESCRIPTION
This pull request is a rebase of pull request #218 that has been updated to use Sesame-4 that was recently released, and targeted at OWLAPI-5 instead of version 4.

There are quite a few warnings, and one failed test, which I need someone else to look at as I don't understand what the warnings are for, and I am not sure how to fix the test. The details for the failing test and the warnings are in the TravisCI logs for the last build.