### PR TITLE
Initial version of hack - always preserve rdfs:class if present.

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/formats/AbstractRDFNonPrefixDocumentFormat.java
+++ b/api/src/main/java/org/semanticweb/owlapi/formats/AbstractRDFNonPrefixDocumentFormat.java
@@ -33,6 +33,10 @@ public abstract class AbstractRDFNonPrefixDocumentFormat extends
     // TODO make something of these
     private final Set<RDFResourceParseError> errors = new HashSet<>();
 
+    public AbstractRDFNonPrefixDocumentFormat() {
+     setOntologyLoaderMetaData(new RDFParserMetaData.NullRDFParserMetadata());
+    }
+
     @Override
     public RDFParserMetaData getOntologyLoaderMetaData() {
         return (RDFParserMetaData) super.getOntologyLoaderMetaData();

--- a/api/src/main/java/org/semanticweb/owlapi/formats/AbstractRDFPrefixDocumentFormat.java
+++ b/api/src/main/java/org/semanticweb/owlapi/formats/AbstractRDFPrefixDocumentFormat.java
@@ -34,6 +34,10 @@ public abstract class AbstractRDFPrefixDocumentFormat extends
     private static final long serialVersionUID = 40000L;
     // TODO make something of these
     private final Set<RDFResourceParseError> errors = new HashSet<>();
+    public AbstractRDFPrefixDocumentFormat() {
+        setOntologyLoaderMetaData(new RDFParserMetaData.NullRDFParserMetadata());
+    }
+
 
     @Override
     public RDFParserMetaData getOntologyLoaderMetaData() {

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFParserMetaData.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFParserMetaData.java
@@ -39,21 +39,22 @@ public class RDFParserMetaData implements OWLOntologyLoaderMetaData,
     private final RDFOntologyHeaderStatus headerStatus;
     private final Set<RDFTriple> unparsedTriples;
     private final ArrayListMultimap<IRI, Class<?>> guessedDeclarations;
-
+    private final Set<IRI> rdfsClassDeclarations;
     /**
      * @param headerStatus
      *        the header status
      * @param tripleCount
      *        the triple count
      * @param unparsedTriples
-     *        the set of triples not parsed
+ *        the set of triples not parsed
      * @param guessedDeclarations
-     *        guessed declarations map
+     * @param rdfsClassDeclarations
      */
     public RDFParserMetaData(@Nonnull RDFOntologyHeaderStatus headerStatus,
-            int tripleCount, @Nonnull Set<RDFTriple> unparsedTriples,
-            @Nonnull ArrayListMultimap<IRI, Class<?>> guessedDeclarations) {
+                             int tripleCount, @Nonnull Set<RDFTriple> unparsedTriples,
+                             @Nonnull ArrayListMultimap<IRI, Class<?>> guessedDeclarations, Set<IRI> rdfsClassDeclarations) {
         this.tripleCount = tripleCount;
+        this.rdfsClassDeclarations = rdfsClassDeclarations;
         this.headerStatus = checkNotNull(headerStatus,
                 "headerStatus cannot be null");
         this.unparsedTriples = checkNotNull(unparsedTriples,
@@ -88,5 +89,13 @@ public class RDFParserMetaData implements OWLOntologyLoaderMetaData,
      */
     public Multimap<IRI, Class<?>> getGuessedDeclarations() {
         return Multimaps.unmodifiableMultimap(guessedDeclarations);
+    }
+
+    /**
+     *
+     * @return  the set of IRIs asserted to be of type rdfs:Class
+     */
+    public Set<IRI> getRdfsClassDeclarations() {
+        return rdfsClassDeclarations;
     }
 }

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFParserMetaData.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFParserMetaData.java
@@ -12,19 +12,17 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi.io;
 
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
-
-import java.io.Serializable;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.util.CollectionFactory;
-
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import org.semanticweb.owlapi.model.IRI;
+import org.semanticweb.owlapi.util.CollectionFactory;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 
 /**
  * @author Matthew Horridge, The University of Manchester, Bio-Health
@@ -62,12 +60,26 @@ public class RDFParserMetaData implements OWLOntologyLoaderMetaData,
         this.guessedDeclarations = checkNotNull(guessedDeclarations,
                 "guessedDeclarations cannot be null");
     }
-
     /**
-     * Gets a count of the triples process during loading.
-     * 
-     * @return The number of triples process during loading.
+     * @param headerStatus
+     *        the header status
+     * @param tripleCount
+     *        the triple count
+     * @param unparsedTriples
+     *        the set of triples not parsed
+     * @param guessedDeclarations
      */
+
+    public RDFParserMetaData(@Nonnull RDFOntologyHeaderStatus headerStatus,
+                             int tripleCount, @Nonnull Set<RDFTriple> unparsedTriples,
+                             @Nonnull ArrayListMultimap<IRI, Class<?>> guessedDeclarations) {
+        this(headerStatus, tripleCount,unparsedTriples, guessedDeclarations,new HashSet<IRI>());
+    }
+        /**
+         * Gets a count of the triples process during loading.
+         *
+         * @return The number of triples process during loading.
+         */
     public int getTripleCount() {
         return tripleCount;
     }
@@ -97,5 +109,13 @@ public class RDFParserMetaData implements OWLOntologyLoaderMetaData,
      */
     public Set<IRI> getRdfsClassDeclarations() {
         return rdfsClassDeclarations;
+    }
+
+    public static class NullRDFParserMetadata extends RDFParserMetaData {
+        private static ArrayListMultimap<IRI,Class<?>> alm = ArrayListMultimap.create(0,0);
+        public NullRDFParserMetadata() {
+            super(RDFOntologyHeaderStatus.PARSED_ZERO_HEADERS, 0,
+                    Collections.<RDFTriple>emptySet(), alm,Collections.<IRI>emptySet());
+        }
     }
 }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -167,6 +167,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker, OWLAno
     @Nonnull
     private final ArrayListMultimap<IRI, Class<?>> guessedDeclarations = ArrayListMultimap.create();
     RemappingIndividualProvider anonProvider;
+    private Set<IRI> rdfsClassDeclarations = new HashSet<>();
 
     /**
      * Instantiates a new oWLRDF consumer.
@@ -1364,7 +1365,7 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker, OWLAno
         Set<RDFTriple> remainingTriples = handlerAccessor.mopUp();
         if (ontologyFormat != null) {
             RDFParserMetaData metaData = new RDFParserMetaData(RDFOntologyHeaderStatus.PARSED_ONE_HEADER, tripleLogger
-                .count(), remainingTriples, guessedDeclarations);
+                .count(), remainingTriples, guessedDeclarations, rdfsClassDeclarations);
             ontologyFormat.setOntologyLoaderMetaData(metaData);
         }
         // Do we need to change the ontology IRI?
@@ -2398,5 +2399,8 @@ public class OWLRDFConsumer implements RDFConsumer, AnonymousNodeChecker, OWLAno
             }
             objects.add(con);
         }
+    }
+    void addRDFSClassDeclaration(IRI rdfsClass) {
+        rdfsClassDeclarations.add(rdfsClass);
     }
 }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
@@ -2906,6 +2906,7 @@ public class TripleHandlers {
         @Override
         public void handleTriple(IRI subject, IRI predicate, IRI object) {
             // TODO: Change to rdfs:Class? (See table 5 in the spec)
+            consumer.addRDFSClassDeclaration(subject);
             consumer.addClassExpression(subject, false);
             consumeTriple(subject, predicate, object);
             if (!isStrict()) {


### PR DESCRIPTION
**DO NOT MERGE**
Test cases failing due to class cast error 
Control via option not done. 
