### PR TITLE
Fix DanglingRoundTripTest#testConvertXPs

### DIFF
--- a/contract/src/test/java/org/obolibrary/obo2owl/DanglingRoundTripTest.java
+++ b/contract/src/test/java/org/obolibrary/obo2owl/DanglingRoundTripTest.java
@@ -1,5 +1,6 @@
 package org.obolibrary.obo2owl;
 
+import java.io.File;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -23,6 +24,6 @@ public class DanglingRoundTripTest extends OboFormatTestBasics {
         assertEquals("sense organ", rc.getValue());
         OBOFormatWriter w = new OBOFormatWriter();
         w.setCheckStructure(true);
-        w.write(d2, "/tmp/z.obo");
+        w.write(d2, File.createTempFile("zzz", ".obo"));
     }
 }

--- a/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
+++ b/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
@@ -135,13 +135,25 @@ public class OBOFormatWriter {
     /**
      * @param doc
      *        the doc
+     * @param outFilename
+     *        the out file name
+     * @throws IOException
+     *         Signals that an I/O exception has occurred.
+     */
+    public void write(@Nonnull OBODoc doc, @Nonnull String outFilename) throws IOException {
+        write(doc, new File(outFilename));
+    }
+	
+	/**
+     * @param doc
+     *        the doc
      * @param outFile
      *        the out file
      * @throws IOException
      *         Signals that an I/O exception has occurred.
      */
-    public void write(@Nonnull OBODoc doc, @Nonnull String outFile) throws IOException {
-        FileOutputStream os = new FileOutputStream(new File(outFile));
+    public void write(@Nonnull OBODoc doc, @Nonnull File outFile) throws IOException {
+        FileOutputStream os = new FileOutputStream(outFile);
         OutputStreamWriter osw = new OutputStreamWriter(os, OBOFormatConstants.DEFAULT_CHARACTER_ENCODING);
         BufferedWriter bw = new BufferedWriter(osw);
         write(doc, bw);


### PR DESCRIPTION
The `DanglingRoundTripTest#testConvertXPs` test failed on Windows because of bad temporary file management.