### PR TITLE
Enhancement for Issue 571 (https://github.com/owlcs/owlapi/issues/571).

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/Translators.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/Translators.java
@@ -798,7 +798,7 @@ public class Translators {
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode,
                     OWL_MAX_QUALIFIED_CARDINALITY)
-                    && isDataPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isDataRangeLax(mainNode, OWL_ON_DATA_RANGE);
         }
 
@@ -890,7 +890,7 @@ public class Translators {
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode,
                     OWL_MIN_QUALIFIED_CARDINALITY)
-                    && isDataPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isDataRangeLax(mainNode, OWL_ON_DATA_RANGE);
         }
 
@@ -955,7 +955,7 @@ public class Translators {
         @Override
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode, OWL_QUALIFIED_CARDINALITY)
-                    && isDataPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isDataRangeLax(mainNode, OWL_ON_DATA_RANGE);
         }
 
@@ -1564,7 +1564,7 @@ public class Translators {
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode,
                     OWL_MAX_QUALIFIED_CARDINALITY)
-                    && isObjectPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isClassExpressionLax(mainNode, OWL_ON_CLASS);
         }
 
@@ -1660,7 +1660,7 @@ public class Translators {
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode,
                     OWL_MIN_QUALIFIED_CARDINALITY)
-                    && isObjectPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isClassExpressionLax(mainNode, OWL_ON_CLASS);
         }
 
@@ -1774,7 +1774,7 @@ public class Translators {
         @Override
         public boolean matchesLax(IRI mainNode) {
             return isNonNegativeIntegerLax(mainNode, OWL_QUALIFIED_CARDINALITY)
-                    && isObjectPropertyLax(mainNode, OWL_ON_PROPERTY)
+                    && isResourcePresent(mainNode, OWL_ON_PROPERTY)
                     && isClassExpressionLax(mainNode, OWL_ON_CLASS);
         }
 


### PR DESCRIPTION
When checking for qualified Object or Datatype cardinalities in LAX, it
is enough for the property just to be present, do not check if it is an
actual Object or Datatype property. The rationale behind this relaxation
of checks is that if someone has correctly declared a onDataRange
restriction property, then he/she intends to create a Datatype property
restriction. In an analogous manner, when someone correctly declares a
onClass restriction property then he/she intends to create an Object
property restriction. Note that for non-qualified restrictions the check
has not been relaxed, because we cannot tell what the intention of the
user is.

No need to merge this, but it would be really nice if you could share some thoughts/comments on my approach here. Thanks in advance!