### PR TITLE
Move protected TOP/BOTTOM constants from impl/org.semanticweb.owlapi.reasoner.impl.DefaultNode into  appropriate subclasses.

### DIFF
--- a/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/DefaultNode.java
+++ b/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/DefaultNode.java
@@ -12,7 +12,8 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi.reasoner.impl;
 
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.*;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
 import static org.semanticweb.owlapi.util.OWLAPIStreamUtils.asUnorderedSet;
 
 import java.util.Collection;
@@ -21,78 +22,50 @@ import java.util.Iterator;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-
 import javax.annotation.Nullable;
-
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDataFactory;
-import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.reasoner.Node;
 import org.semanticweb.owlapi.util.OWLAPIStreamUtils;
 
-import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
-
 /**
- * @author Matthew Horridge, The University of Manchester, Information
- *         Management Group
+ * @param <E> the type of entities in the node
+ * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
- * @param <E>
- *        the type of entities in the node
  */
 public abstract class DefaultNode<E extends OWLObject> implements Node<E> {
 
-    private static final OWLDataFactory DF = new OWLDataFactoryImpl(false);
-    protected static final OWLClass TOP_CLASS = DF.getOWLThing();
-    protected static final OWLClassNode TOP_NODE = new OWLClassNode(TOP_CLASS);
-    protected static final OWLClass BOTTOM_CLASS = DF.getOWLNothing();
-    protected static final OWLClassNode BOTTOM_NODE = new OWLClassNode(BOTTOM_CLASS);
-    protected static final OWLDataProperty TOP_DATA_PROPERTY = DF.getOWLTopDataProperty();
-    protected static final OWLDataPropertyNode TOP_DATA_NODE = new OWLDataPropertyNode(TOP_DATA_PROPERTY);
-    protected static final OWLDataProperty BOTTOM_DATA_PROPERTY = DF.getOWLBottomDataProperty();
-    protected static final OWLDataPropertyNode BOTTOM_DATA_NODE = new OWLDataPropertyNode(BOTTOM_DATA_PROPERTY);
-    protected static final OWLDatatype TOP_DATATYPE = DF.getTopDatatype();
-    protected static final OWLObjectProperty TOP_OBJECT_PROPERTY = DF.getOWLTopObjectProperty();
-    protected static final OWLObjectPropertyNode TOP_OBJECT_NODE = new OWLObjectPropertyNode(TOP_OBJECT_PROPERTY);
-    protected static final OWLObjectProperty BOTTOM_OBJECT_PROPERTY = DF.getOWLBottomObjectProperty();
-    protected static final OWLObjectPropertyNode BOTTOM_OBJECT_NODE = new OWLObjectPropertyNode(BOTTOM_OBJECT_PROPERTY);
     private final Set<E> entities = new HashSet<>(4);
 
     /**
-     * @param entity
-     *        the entity to add
+     * @param entity the entity to add
      */
     public DefaultNode(E entity) {
         entities.add(checkNotNull(entity, "entity cannot be null"));
     }
 
     /**
-     * @param entities
-     *        the entities to add
+     * @param entities the entities to add
      */
     public DefaultNode(Collection<E> entities) {
         this.entities.addAll(checkNotNull(entities, "entities cannot be null"));
     }
 
     /**
-     * @param entities
-     *        the entities to add
+     * @param entities the entities to add
      */
     public DefaultNode(Stream<E> entities) {
         OWLAPIStreamUtils.add(this.entities, checkNotNull(entities, "entities cannot be null"));
     }
 
-    protected DefaultNode() {}
+    protected DefaultNode() {
+    }
 
     protected abstract Optional<E> getTopEntity();
 
     protected abstract Optional<E> getBottomEntity();
 
     /**
-     * @param entity
-     *        entity to be added
+     * @param entity entity to be added
      */
     public void add(E entity) {
         entities.add(entity);

--- a/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLClassNode.java
+++ b/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLClassNode.java
@@ -17,6 +17,8 @@ import java.util.Optional;
 import java.util.stream.Stream;
 
 import org.semanticweb.owlapi.model.OWLClass;
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /**
  * @author Matthew Horridge, The University of Manchester, Information
@@ -24,6 +26,19 @@ import org.semanticweb.owlapi.model.OWLClass;
  * @since 3.0.0
  */
 public class OWLClassNode extends DefaultNode<OWLClass> {
+
+    private static final OWLClass TOP_CLASS;
+    private static final OWLClassNode TOP_NODE;
+    private static final OWLClass BOTTOM_CLASS;
+    private static final OWLClassNode BOTTOM_NODE;
+
+    static {
+        OWLDataFactory factory = new OWLDataFactoryImpl(false);
+        TOP_CLASS = factory.getOWLThing();
+        TOP_NODE = new OWLClassNode(TOP_CLASS);
+        BOTTOM_CLASS = factory.getOWLNothing();
+        BOTTOM_NODE = new OWLClassNode(BOTTOM_CLASS);
+    }
 
     /**
      * @param entity
@@ -54,16 +69,6 @@ public class OWLClassNode extends DefaultNode<OWLClass> {
         super();
     }
 
-    @Override
-    protected Optional<OWLClass> getTopEntity() {
-        return Optional.of(TOP_CLASS);
-    }
-
-    @Override
-    protected Optional<OWLClass> getBottomEntity() {
-        return Optional.of(BOTTOM_CLASS);
-    }
-
     /**
      * @return singleton top node
      */
@@ -76,5 +81,15 @@ public class OWLClassNode extends DefaultNode<OWLClass> {
      */
     public static OWLClassNode getBottomNode() {
         return BOTTOM_NODE;
+    }
+
+    @Override
+    protected Optional<OWLClass> getTopEntity() {
+        return Optional.of(TOP_CLASS);
+    }
+
+    @Override
+    protected Optional<OWLClass> getBottomEntity() {
+        return Optional.of(BOTTOM_CLASS);
     }
 }

--- a/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLDataPropertyNode.java
+++ b/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLDataPropertyNode.java
@@ -15,40 +15,52 @@ package org.semanticweb.owlapi.reasoner.impl;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
-
+import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDataProperty;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /**
- * @author Matthew Horridge, The University of Manchester, Information
- *         Management Group
+ * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
  */
 public class OWLDataPropertyNode extends DefaultNode<OWLDataProperty> {
 
-    /** Default constructor. */
+    private static final OWLDataProperty TOP_DATA_PROPERTY;
+    private static final OWLDataPropertyNode TOP_DATA_NODE;
+    private static final OWLDataProperty BOTTOM_DATA_PROPERTY;
+    private static final OWLDataPropertyNode BOTTOM_DATA_NODE;
+
+    static {
+
+        OWLDataFactory DF = new OWLDataFactoryImpl(false);
+        TOP_DATA_PROPERTY = DF.getOWLTopDataProperty();
+        TOP_DATA_NODE = new OWLDataPropertyNode(TOP_DATA_PROPERTY);
+        BOTTOM_DATA_PROPERTY = DF.getOWLBottomDataProperty();
+        BOTTOM_DATA_NODE = new OWLDataPropertyNode(BOTTOM_DATA_PROPERTY);
+    }
+    /**
+     * Default constructor.
+     */
     public OWLDataPropertyNode() {
         super();
     }
 
     /**
-     * @param entity
-     *        the entity to be contained
+     * @param entity the entity to be contained
      */
     public OWLDataPropertyNode(OWLDataProperty entity) {
         super(entity);
     }
 
     /**
-     * @param entities
-     *        the entities to be contained
+     * @param entities the entities to be contained
      */
     public OWLDataPropertyNode(Collection<OWLDataProperty> entities) {
         super(entities);
     }
 
     /**
-     * @param entities
-     *        the entities to be contained
+     * @param entities the entities to be contained
      */
     public OWLDataPropertyNode(Stream<OWLDataProperty> entities) {
         super(entities);

--- a/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLDatatypeNode.java
+++ b/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLDatatypeNode.java
@@ -15,40 +15,46 @@ package org.semanticweb.owlapi.reasoner.impl;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
-
+import org.semanticweb.owlapi.model.OWLDataFactory;
 import org.semanticweb.owlapi.model.OWLDatatype;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /**
- * @author Matthew Horridge, The University of Manchester, Information
- *         Management Group
+ * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
  */
 public class OWLDatatypeNode extends DefaultNode<OWLDatatype> {
 
-    /** Default constructor. */
+    private static final OWLDatatype TOP_DATATYPE;
+
+    static {
+        OWLDataFactory DF = new OWLDataFactoryImpl(false);
+        TOP_DATATYPE = DF.getTopDatatype();
+    }
+
+    /**
+     * Default constructor.
+     */
     public OWLDatatypeNode() {
         super();
     }
 
     /**
-     * @param entity
-     *        datatype to include
+     * @param entity datatype to include
      */
     public OWLDatatypeNode(OWLDatatype entity) {
         super(entity);
     }
 
     /**
-     * @param entities
-     *        set of datatypes to include
+     * @param entities set of datatypes to include
      */
     public OWLDatatypeNode(Collection<OWLDatatype> entities) {
         super(entities);
     }
 
     /**
-     * @param entities
-     *        set of datatypes to include
+     * @param entities set of datatypes to include
      */
     public OWLDatatypeNode(Stream<OWLDatatype> entities) {
         super(entities);

--- a/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLObjectPropertyNode.java
+++ b/impl/src/main/java/org/semanticweb/owlapi/reasoner/impl/OWLObjectPropertyNode.java
@@ -15,40 +15,53 @@ package org.semanticweb.owlapi.reasoner.impl;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.stream.Stream;
-
+import org.semanticweb.owlapi.model.OWLDataFactory;
+import org.semanticweb.owlapi.model.OWLObjectProperty;
 import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
+import uk.ac.manchester.cs.owl.owlapi.OWLDataFactoryImpl;
 
 /**
- * @author Matthew Horridge, The University of Manchester, Information
- *         Management Group
+ * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
  */
 public class OWLObjectPropertyNode extends DefaultNode<OWLObjectPropertyExpression> {
 
-    /** Default constructor. */
+    private static final OWLObjectProperty TOP_OBJECT_PROPERTY;
+    private static final OWLObjectPropertyNode TOP_OBJECT_NODE;
+    private static final OWLObjectProperty BOTTOM_OBJECT_PROPERTY;
+    private static final OWLObjectPropertyNode BOTTOM_OBJECT_NODE;
+
+    static {
+
+        OWLDataFactory DF = new OWLDataFactoryImpl(false);
+        TOP_OBJECT_PROPERTY = DF.getOWLTopObjectProperty();
+        TOP_OBJECT_NODE = new OWLObjectPropertyNode(TOP_OBJECT_PROPERTY);
+        BOTTOM_OBJECT_PROPERTY = DF.getOWLBottomObjectProperty();
+        BOTTOM_OBJECT_NODE = new OWLObjectPropertyNode(BOTTOM_OBJECT_PROPERTY);
+    }
+    /**
+     * Default constructor.
+     */
     public OWLObjectPropertyNode() {
         super();
     }
 
     /**
-     * @param entity
-     *        property to include
+     * @param entity property to include
      */
     public OWLObjectPropertyNode(OWLObjectPropertyExpression entity) {
         super(entity);
     }
 
     /**
-     * @param entities
-     *        properties to include
+     * @param entities properties to include
      */
     public OWLObjectPropertyNode(Collection<OWLObjectPropertyExpression> entities) {
         super(entities);
     }
 
     /**
-     * @param entities
-     *        properties to include
+     * @param entities properties to include
      */
     public OWLObjectPropertyNode(Stream<OWLObjectPropertyExpression> entities) {
         super(entities);


### PR DESCRIPTION
Referencing a subclass from a field  initializer in the superclass can cause deadlocks in class loaders.