### PR TITLE
Add predicates for  "simple literal" so rendering doesn't add explicit xsd:string to everything.

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -161,6 +161,10 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
         return OWL2Datatype.RDF_PLAIN_LITERAL.getIRI().equals(datatype);
     }
 
+    public boolean isSimpleLiteral() {
+        return datatype.equals( OWL2Datatype.RDF_LANG_STRING.getIRI()) ||
+                datatype.equals(OWL2Datatype.XSD_STRING.getIRI());
+    }
     @Override
     public int compareTo(@Nullable RDFNode o) {
         checkNotNull(o);

--- a/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/io/RDFLiteral.java
@@ -161,6 +161,12 @@ public class RDFLiteral extends RDFNode implements org.apache.commons.rdf.api.Li
         return OWL2Datatype.RDF_PLAIN_LITERAL.getIRI().equals(datatype);
     }
 
+
+    /**
+     *
+     * @return true if this node is an RDF 1.1 Simple Literal
+     */
+
     public boolean isSimpleLiteral() {
         return datatype.equals( OWL2Datatype.RDF_LANG_STRING.getIRI()) ||
                 datatype.equals(OWL2Datatype.XSD_STRING.getIRI());

--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLLiteral.java
@@ -71,6 +71,8 @@ public interface OWLLiteral
         return false;
     }
 
+    default boolean isSimpleLiteral() {return false;}
+
     /**
      * Gets the lexical value of this literal. Note that if the datatype is
      * {@code rdf:PlainLiteral} then the abbreviated lexical form will be

--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLLiteral.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLLiteral.java
@@ -71,6 +71,10 @@ public interface OWLLiteral
         return false;
     }
 
+    /**
+     *
+     * @return true if this literal is an RDF 1.1 Simple Literal
+     */
     default boolean isSimpleLiteral() {return false;}
 
     /**

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/LiteralTestCase.java
@@ -64,10 +64,17 @@ public class LiteralTestCase extends TestBase {
     }
 
     @Test
+    public void testStringIsSimple() {
+        OWLLiteral literal = Literal("hello world");
+        assertEquals(literal.getDatatype(),OWL2Datatype.XSD_STRING.getDatatype(df));
+        assertTrue(literal.isSimpleLiteral());
+    }
+    @Test
     public void testPlainLiteralWithLang() {
         OWLLiteral literalWithLang = Literal("abc", "en");
         assertFalse(literalWithLang.getDatatype().getIRI().isPlainLiteral());
         assertFalse(literalWithLang.isRDFPlainLiteral());
+        assertTrue(literalWithLang.isSimpleLiteral());
         assertTrue(literalWithLang.hasLang());
         assertEquals("en", literalWithLang.getLang());
         assertEquals(literalWithLang.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));
@@ -78,6 +85,8 @@ public class LiteralTestCase extends TestBase {
         OWLLiteral literal = Literal("abc@en", PlainLiteral());
         assertTrue(literal.hasLang());
         assertFalse(literal.isRDFPlainLiteral());
+        assertTrue(literal.isSimpleLiteral());
+
         assertEquals("en", literal.getLang());
         assertEquals("abc", literal.getLiteral());
         assertEquals(literal.getDatatype(), OWL2Datatype.RDF_LANG_STRING.getDatatype(df));

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -12,6 +12,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package uk.ac.manchester.cs.owl.owlapi;
 
+import org.semanticweb.owlapi.model.IRI;
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
 import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
 
@@ -101,6 +102,12 @@ public class OWLLiteralImpl extends OWLObjectImpl implements OWLLiteral {
     @Override
     public boolean isRDFPlainLiteral() {
         return getDatatype().isRDFPlainLiteral();
+    }
+
+    @Override
+    public boolean isSimpleLiteral() {
+        IRI iri = getDatatype().getIRI();
+        return iri.equals(RDF_LANG_STRING.getIRI()) || iri.equals(XSD_STRING.getIRI());
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplNoCompression.java
@@ -14,6 +14,7 @@ package uk.ac.manchester.cs.owl.owlapi;
 
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLDatatype;
 import org.semanticweb.owlapi.model.OWLLiteral;
 import org.semanticweb.owlapi.model.OWLObject;
@@ -77,6 +78,11 @@ public class OWLLiteralImplNoCompression extends OWLObjectImpl implements OWLLit
     @Override
     public boolean isRDFPlainLiteral() {
         return getDatatype().isRDFPlainLiteral();
+    }
+    @Override
+    public boolean isSimpleLiteral() {
+        IRI iri = getDatatype().getIRI();
+        return iri.equals(RDF_LANG_STRING.getIRI()) || iri.equals(XSD_STRING.getIRI());
     }
 
     @Override

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplPlain.java
@@ -61,6 +61,11 @@ public class OWLLiteralImplPlain extends OWLObjectImpl implements OWLLiteral {
     }
 
     @Override
+    public boolean isSimpleLiteral() {
+        return true;
+    }
+
+    @Override
     public String getLang() {
         return lang;
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplString.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplString.java
@@ -50,4 +50,9 @@ public class OWLLiteralImplString extends OWLObjectImpl implements OWLLiteral {
             Stream.of(getDatatype(), Integer.valueOf(getLiteral().hashCode() * 65536),
                 getLang()));
     }
+
+    @Override
+    public boolean isSimpleLiteral() {
+        return true;
+    }
 }

--- a/parsers/src/main/java/org/semanticweb/owlapi/functional/renderer/FunctionalSyntaxObjectRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/functional/renderer/FunctionalSyntaxObjectRenderer.java
@@ -1130,7 +1130,7 @@ public class FunctionalSyntaxObjectRenderer implements OWLObjectVisitor {
         if (node.hasLang()) {
             write("@");
             write(node.getLang());
-        } else if (!node.isRDFPlainLiteral()) {
+        } else if (!node.isSimpleLiteral()) {
             write("^^");
             write(node.getDatatype().getIRI());
         }

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxObjectRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxObjectRenderer.java
@@ -515,7 +515,7 @@ public class ManchesterOWLSyntaxObjectRenderer extends AbstractRenderer implemen
             if (node.hasLang()) {
                 write("@");
                 write(node.getLang());
-            } else if (!node.isRDFPlainLiteral()) {
+            } else if (!node.isSimpleLiteral()) {
                 write("^^");
                 node.getDatatype().accept(this);
             }

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/renderer/RDFXMLRenderer.java
@@ -12,19 +12,11 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi.rdf.rdfxml.renderer;
 
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
-import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
-import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.BUILT_IN_VOCABULARY_IRIS;
-import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.RDFS_LITERAL;
-import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.RDF_DESCRIPTION;
-import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.RDF_TYPE;
-
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,21 +26,14 @@ import org.semanticweb.owlapi.io.RDFResource;
 import org.semanticweb.owlapi.io.RDFResourceBlankNode;
 import org.semanticweb.owlapi.io.RDFTriple;
 import org.semanticweb.owlapi.io.XMLUtils;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDatatype;
-import org.semanticweb.owlapi.model.OWLDocumentFormat;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLNamedIndividual;
-import org.semanticweb.owlapi.model.OWLObjectProperty;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLOntologyManager;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.rdf.RDFRendererBase;
 import org.semanticweb.owlapi.util.AnnotationValueShortFormProvider;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.checkNotNull;
+import static org.semanticweb.owlapi.util.OWLAPIPreconditions.verifyNotNull;
 import org.semanticweb.owlapi.util.ShortFormProvider;
 import org.semanticweb.owlapi.util.VersionInfo;
+import static org.semanticweb.owlapi.vocab.OWLRDFVocabulary.*;
 
 /**
  * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
@@ -226,7 +211,7 @@ public class RDFXMLRenderer extends RDFRendererBase {
                                 if (n.isLiteral()) {
                                     RDFLiteral litNode = (RDFLiteral) n;
                                     writer.writeStartElement(RDFS_LITERAL.getIRI());
-                                    if (!litNode.isPlainLiteral()) {
+                                    if (!litNode.isSimpleLiteral()) {
                                         writer.writeDatatypeAttribute(litNode.getDatatype());
                                     } else if (litNode.hasLang()) {
                                         writer.writeLangAttribute(litNode.getLang());
@@ -253,7 +238,7 @@ public class RDFXMLRenderer extends RDFRendererBase {
                 RDFLiteral rdfLiteralNode = (RDFLiteral) objectNode;
                 if (rdfLiteralNode.hasLang()) {
                     writer.writeLangAttribute(rdfLiteralNode.getLang());
-                } else if (!rdfLiteralNode.isPlainLiteral()) {
+                } else if (!rdfLiteralNode.isSimpleLiteral()) {
                     writer.writeDatatypeAttribute(rdfLiteralNode.getDatatype());
                 }
                 writer.writeTextContent(rdfLiteralNode.getLexicalValue());

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/turtle/renderer/TurtleRenderer.java
@@ -222,7 +222,7 @@ public class TurtleRenderer extends RDFRendererBase {
     }
 
     private void write(RDFLiteral node) {
-        if (!node.isPlainLiteral()) {
+        if (!node.isSimpleLiteral()) {
             if (node.getDatatype().equals(XSDVocabulary.INTEGER.getIRI())) {
                 write(node.getLexicalValue());
             } else if (node.getDatatype().equals(XSDVocabulary.DECIMAL.getIRI())) {


### PR DESCRIPTION
This might possibly need to be set by a flag; alternatively, only LiteralImplPlain could admit to being simple.

This almost duplicates isPlainLiteral, except for one rio test case, involving a constructed triple with explicit datatype PlainLiteral.