### PR TITLE
Update OBOFormatWriter.java to emit OBO 1.4 compliant text

### DIFF
--- a/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
+++ b/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
@@ -298,13 +298,9 @@ public class OBOFormatWriter {
         while (it.hasNext()) {
             sb.append(' ');
             String val = it.next().toString(); // TODO replace toString() method
-            if (val.contains(" ") || !val.contains(":")) {
-                sb.append('"');
-                sb.append(escapeOboString(val, EscapeMode.QUOTES));
-                sb.append('"');
-            } else {
-                sb.append(escapeOboString(val, EscapeMode.SIMPLE));
-            }
+            sb.append('"');
+            sb.append(escapeOboString(val, EscapeMode.QUOTES));
+            sb.append('"');
         }
         appendQualifiers(sb, clause);
         writeLine(sb, writer);


### PR DESCRIPTION
Hi there, 

while working on the OBO 1.4 syntax with @cmungall we realised `owlapi` was not emitting proper OBO for property values, since the newer syntax requires the value to be escaped at all times. This PR should take care of that !