### PR TITLE
Make pruning window size configurable

### DIFF
--- a/tools/src/main/java/com/clarkparsia/owlapi/explanation/BlackBoxExplanation.java
+++ b/tools/src/main/java/com/clarkparsia/owlapi/explanation/BlackBoxExplanation.java
@@ -130,8 +130,8 @@ public class BlackBoxExplanation extends SingleExplanationGeneratorImpl
      */
     public BlackBoxExplanation(OWLOntology ontology, OWLReasonerFactory reasonerFactory,
         OWLReasoner reasoner, Integer fastPruningWindowSize) {
+        this(ontology, reasonerFactory, reasoner);
         this.fastPruningWindowSize = fastPruningWindowSize;
-        BlackBoxExplanation(ontology, reasonerFactory, reasoner);
     }
 
     /**

--- a/tools/src/main/java/com/clarkparsia/owlapi/explanation/BlackBoxExplanation.java
+++ b/tools/src/main/java/com/clarkparsia/owlapi/explanation/BlackBoxExplanation.java
@@ -102,7 +102,8 @@ public class BlackBoxExplanation extends SingleExplanationGeneratorImpl
     /**
      * The fast pruning window size.
      */
-    private int fastPruningWindowSize;
+    private int fastPruningWindowSize = DEFAULT_FAST_PRUNING_WINDOW_SIZE;
+
     // Creation of debugging ontology and satisfiability testing
     private int satTestCount;
 
@@ -117,6 +118,20 @@ public class BlackBoxExplanation extends SingleExplanationGeneratorImpl
         OWLReasoner reasoner) {
         super(ontology, reasonerFactory, reasoner);
         man = ontology.getOWLOntologyManager();
+    }
+    
+   /**
+     * Instantiates a new black box explanation.
+     *
+     * @param ontology the ontology
+     * @param reasonerFactory the reasoner factory
+     * @param reasoner the reasoner
+     * @param fastPruningWindowSize the window size for fast pruning (default 10)
+     */
+    public BlackBoxExplanation(OWLOntology ontology, OWLReasonerFactory reasonerFactory,
+        OWLReasoner reasoner, Integer fastPruningWindowSize) {
+        this.fastPruningWindowSize = fastPruningWindowSize;
+        BlackBoxExplanation(ontology, reasonerFactory, reasoner);
     }
 
     /**
@@ -420,7 +435,6 @@ public class BlackBoxExplanation extends SingleExplanationGeneratorImpl
         LOGGER.info("FOUND CLASH! Pruning {} axioms...", Integer.valueOf(debuggingAxioms.size()));
         resetSatisfiabilityTestCounter();
         LOGGER.info("Fast pruning...");
-        fastPruningWindowSize = DEFAULT_FAST_PRUNING_WINDOW_SIZE;
         performFastPruning(unsatClass);
         LOGGER.info("... end of fast pruning. Axioms remaining: {}",
             Integer.valueOf(debuggingAxioms.size()));


### PR DESCRIPTION
Make the window size for fast pruning step in black box explainer configurable. This is especially helpful for very large ontologies, where window sizes of ten may leave you with a 'fast' pruning duration of weeks, even on a very powerful computer. Ideally, you could make a simple heuristic based on the number of axioms in the ontology (for anyone struggling, values of 1000+ for MONDO and ontologies of a similar sizes has helped a lot), but this will do for now.

If this isn't the preferred style for making a parameter, please let me know and I can change it.