### PR TITLE
After

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/model/axiomproviders/EquivalentAxiomProvider.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/axiomproviders/EquivalentAxiomProvider.java
@@ -43,6 +43,17 @@ public interface EquivalentAxiomProvider {
 
     /**
      * @param classExpressions equivalent classes. Cannot be null or contain nulls.
+     * @param keepDuplicates whether to keep duplicate items
+     * @return an equivalent classes axiom with specified operands and no annotations
+     */
+    default OWLEquivalentClassesAxiom
+    getOWLEquivalentClassesAxiom(Collection<? extends OWLClassExpression> classExpressions,
+                                 boolean keepDuplicates) {
+        return getOWLEquivalentClassesAxiom(classExpressions, Collections.emptySet(), keepDuplicates);
+    }
+
+    /**
+     * @param classExpressions equivalent classes. Cannot be null or contain nulls.
      * @return an equivalent classes axiom with specified operands and no annotations
      */
     default OWLEquivalentClassesAxiom
@@ -58,6 +69,16 @@ public interface EquivalentAxiomProvider {
     OWLEquivalentClassesAxiom getOWLEquivalentClassesAxiom(
         Collection<? extends OWLClassExpression> classExpressions,
         Collection<OWLAnnotation> annotations);
+
+    /**
+     * @param classExpressions equivalent classes. Cannot be null or contain nulls.
+     * @param annotations A set of annotations. Cannot be null or contain nulls.
+     * @param keepDuplicates whether to keep duplicate items
+     * @return an equivalent classes axiom with specified operands and annotations
+     */
+    OWLEquivalentClassesAxiom getOWLEquivalentClassesAxiom(
+            Collection<? extends OWLClassExpression> classExpressions,
+            Collection<OWLAnnotation> annotations, boolean keepDuplicates);
 
     /**
      * @param classExpressions equivalent classes. Cannot be null or contain nulls.
@@ -83,6 +104,19 @@ public interface EquivalentAxiomProvider {
     /**
      * @param clsA one class for equivalence
      * @param clsB one class for equivalence
+     * @param keepDuplicates whether to keep duplicate items
+     * @return an equivalent classes axiom with specified operands and no annotations (special case
+     * with only two operands)
+     */
+    default OWLEquivalentClassesAxiom getOWLEquivalentClassesAxiom(OWLClassExpression clsA,
+                                                                   OWLClassExpression clsB,
+                                                                   boolean keepDuplicates) {
+        return getOWLEquivalentClassesAxiom(clsA, clsB, Collections.emptySet(), keepDuplicates);
+    }
+
+    /**
+     * @param clsA one class for equivalence
+     * @param clsB one class for equivalence
      * @param annotations A set of annotations. Cannot be null or contain nulls.
      * @return an equivalent classes axiom with specified operands and annotations (special case
      * with only two operands)
@@ -91,6 +125,26 @@ public interface EquivalentAxiomProvider {
         OWLClassExpression clsB,
         Collection<OWLAnnotation> annotations) {
         return getOWLEquivalentClassesAxiom(CollectionFactory.createSet(clsA, clsB), annotations);
+    }
+
+    /**
+     * @param clsA one class for equivalence
+     * @param clsB one class for equivalence
+     * @param annotations A set of annotations. Cannot be null or contain nulls.
+     * @param keepDuplicates whether to keep duplicate items
+     * @return an equivalent classes axiom with specified operands and annotations (special case
+     * with only two operands)
+     */
+    default OWLEquivalentClassesAxiom getOWLEquivalentClassesAxiom(OWLClassExpression clsA,
+                                                                   OWLClassExpression clsB,
+                                                                   Collection<OWLAnnotation> annotations,
+                                                                   boolean keepDuplicates) {
+        if (keepDuplicates){
+            return getOWLEquivalentClassesAxiom(CollectionFactory.createList(clsA, clsB), annotations, keepDuplicates);
+        }
+        else{
+            return getOWLEquivalentClassesAxiom(CollectionFactory.createSet(clsA, clsB), annotations);
+        }
     }
 
     /**

--- a/api/src/main/java/org/semanticweb/owlapi/util/OWLAPIStreamUtils.java
+++ b/api/src/main/java/org/semanticweb/owlapi/util/OWLAPIStreamUtils.java
@@ -53,6 +53,27 @@ public class OWLAPIStreamUtils {
     /**
      * @param <T> type
      * @param type type of the returned array
+     * @param s stream to turn to sorted, duplicate free, no null, list
+     * @param keepDuplicates whether to keep the duplicates in the stream
+     * @return sorted array containing all elements in the stream, without nulls.
+     * Duplicates are also removed if {@code keepDuplicates} is false. The list is immutable.
+     */
+    public static <T> List<T> sorted(Class<T> type, Stream<? extends T> s, boolean keepDuplicates) {
+        // skip nulls, ensure sorted
+        if (keepDuplicates){
+            return Collections
+                    .unmodifiableList(asList(s.filter(Objects::nonNull).sorted(), type));
+        }
+        else{
+            // skip duplicates as well
+            return Collections
+                    .unmodifiableList(asList(s.filter(Objects::nonNull).distinct().sorted(), type));
+        }
+    }
+
+    /**
+     * @param <T> type
+     * @param type type of the returned array
      * @param c collection to turn to sorted, duplicate free, no null, list
      * @return sorted array containing all elements in the collection, minus nulls and duplicates.
      *         The list is immutable.
@@ -68,6 +89,27 @@ public class OWLAPIStreamUtils {
             return sorted(type, (Set<? extends T>) c);
         }
         return sorted(type, c.stream());
+    }
+
+    /**
+     * @param <T> type
+     * @param type type of the returned array
+     * @param c collection to turn to sorted, duplicate free, no null, list
+     * @param keepDuplicates whether to keep duplicate classes. Not applicable if {@code c} is a set
+     * @return sorted array containing all elements in the collection, minus nulls and duplicates.
+     *         The list is immutable.
+     */
+    public static <T> List<T> sorted(Class<T> type, Collection<? extends T> c, boolean keepDuplicates) {
+        if (c.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (c instanceof List) {
+            return sorted(type, (List<? extends T>) c, keepDuplicates);
+        }
+        if (c instanceof Set) {
+            return sorted(type, (Set<? extends T>) c);
+        }
+        return sorted(type, c.stream(), keepDuplicates);
     }
 
     /**
@@ -92,6 +134,36 @@ public class OWLAPIStreamUtils {
                 list.remove(i);
             } else {
                 i++;
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    /**
+     * @param <T> type
+     * @param type type of the returned array
+     * @param c collection to turn to sorted, duplicate free, no null, list
+     * @param keepDuplicates whether to keep the duplicates in the stream
+     * @return sorted array containing all elements in the collection, without nulls.
+     * Duplicates are also removed if {@code keepDuplicates} is false. The list is immutable.
+     */
+    public static <T> List<T> sorted(Class<T> type, List<? extends T> c, boolean keepDuplicates) {
+        List<T> list = new ArrayList<>(c);
+        for (int i = 0; i < list.size();) {
+            if (list.get(i) == null) {
+                list.remove(i);
+            } else {
+                i++;
+            }
+        }
+        if (!keepDuplicates) {
+            list.sort(null);
+            for (int i = 1; i < list.size(); ) {
+                if (list.get(i).equals(list.get(i - 1))) {
+                    list.remove(i);
+                } else {
+                    i++;
+                }
             }
         }
         return Collections.unmodifiableList(list);

--- a/contract/src/test/java/org/semanticweb/owlapi/examples/Examples.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/examples/Examples.java
@@ -1798,6 +1798,29 @@ public class Examples extends TestBase {
         manager.saveOntology(ont, new TurtleDocumentFormat(), new StringDocumentTarget());
     }
 
+    @Test
+    public void shouldKeepDuplicatesIfAsked() throws Exception {
+        OWLOntologyManager manager = OWLManager.createOWLOntologyManager();
+        IRI ontologyIRI = IRI.create("http://example.com/owlapi/", "families");
+        OWLOntology ont = manager.createOntology(ontologyIRI);
+        OWLDataFactory factory = manager.getOWLDataFactory();
+
+        // Equivalence Tautology
+        OWLClass person = factory.getOWLClass(ontologyIRI + "#", "Person");
+        OWLEquivalentClassesAxiom equivalenceTautology = factory
+                .getOWLEquivalentClassesAxiom(person, person);
+        manager.addAxiom(ont, equivalenceTautology);
+        assertEquals(2, equivalenceTautology.classExpressions().count());
+        // System.out.println(equivalenceTautology);
+
+        // SubClass Tautology
+        OWLSubClassOfAxiom subclassTautology = factory
+                .getOWLSubClassOfAxiom(person, person);
+        manager.addAxiom(ont, subclassTautology);
+        assertEquals(3, subclassTautology.components().count());
+        // System.out.println(subclassTautology);
+    }
+
     /**
      * Visits existential restrictions and collects the properties which are
      * restricted.

--- a/contract/src/test/java/org/semanticweb/owlapi/examples/Examples.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/examples/Examples.java
@@ -1808,7 +1808,7 @@ public class Examples extends TestBase {
         // Equivalence Tautology
         OWLClass person = factory.getOWLClass(ontologyIRI + "#", "Person");
         OWLEquivalentClassesAxiom equivalenceTautology = factory
-                .getOWLEquivalentClassesAxiom(person, person);
+                .getOWLEquivalentClassesAxiom(person, person, true);
         manager.addAxiom(ont, equivalenceTautology);
         assertEquals(2, equivalenceTautology.classExpressions().count());
         // System.out.println(equivalenceTautology);

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLDataFactoryImpl.java
@@ -756,6 +756,15 @@ public class OWLDataFactoryImpl implements OWLDataFactory, Serializable, ClassPr
     }
 
     @Override
+    public OWLEquivalentClassesAxiom getOWLEquivalentClassesAxiom(
+            Collection<? extends OWLClassExpression> classExpressions,
+            Collection<OWLAnnotation> annotations, boolean keepDuplicates) {
+        checkIterableNotNull(classExpressions, CLASS_EXPRESSIONS_CANNOT_BE_NULL, true);
+        checkAnnotations(annotations);
+        return new OWLEquivalentClassesAxiomImpl(classExpressions, annotations, keepDuplicates);
+    }
+
+    @Override
     public OWLEquivalentDataPropertiesAxiom getOWLEquivalentDataPropertiesAxiom(
         Collection<? extends OWLDataPropertyExpression> properties,
         Collection<OWLAnnotation> annotations) {

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLEquivalentClassesAxiomImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLEquivalentClassesAxiomImpl.java
@@ -41,6 +41,17 @@ public class OWLEquivalentClassesAxiomImpl extends OWLNaryClassAxiomImpl
         super(classExpressions, annotations);
     }
 
+    /**
+     * @param classExpressions equivalent classes
+     * @param annotations annotations
+     * @param keepDuplicates whether to keep duplicate classes
+     */
+    public OWLEquivalentClassesAxiomImpl(Collection<? extends OWLClassExpression> classExpressions,
+                                         Collection<OWLAnnotation> annotations,
+                                         boolean keepDuplicates) {
+        super(classExpressions, annotations, keepDuplicates);
+    }
+
     private static boolean named(OWLClassExpression d) {
         return !d.isAnonymous() && !d.isOWLNothing() && !d.isOWLThing();
     }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLNaryClassAxiomImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLNaryClassAxiomImpl.java
@@ -45,6 +45,17 @@ public abstract class OWLNaryClassAxiomImpl extends OWLClassAxiomImpl implements
         this.classExpressions = sorted(OWLClassExpression.class, classExpressions);
     }
 
+    /**
+     * @param classExpressions classes
+     * @param annotations annotations
+     */
+    public OWLNaryClassAxiomImpl(Collection<? extends OWLClassExpression> classExpressions,
+                                 Collection<OWLAnnotation> annotations, boolean keepDuplicates) {
+        super(annotations);
+        checkNotNull(classExpressions, "classExpressions cannot be null");
+        this.classExpressions = sorted(OWLClassExpression.class, classExpressions, keepDuplicates);
+    }
+
     @Override
     public Stream<OWLClassExpression> classExpressions() {
         return streamFromSorted(classExpressions);


### PR DESCRIPTION
Fixed issue https://github.com/owlcs/owlapi/issues/776

Only two axioms require duplicates to create tautologies - subclass (SubClass (A, A) and equivalence Equivalence(A, A)). Out of these, equivalence class axioms remove the duplicates from the class Expressions.

In this fix, an overload of the existing functions is added to EquivalentAxiomProvider to enable user to force the provider to ignore duplicates in the input class expressions.