### PR TITLE
ISSUE-950 Augment 'Deprecated use the stream method' Javadoc for OWLOntology

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLOntology.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLOntology.java
@@ -217,7 +217,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      *         ontology while iterating over this set.
      * @throws UnknownOWLOntologyException if this ontology is no longer managed by its manager
      *         because it was removed from the manager.
-     * @deprecated use the stream method
+     * @deprecated use {@link #imports()}
      */
     @Deprecated
     default Set<OWLOntology> getImports() {
@@ -249,7 +249,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      *         that are directly imported by this ontology. The set that is returned is a copy - it
      *         will not be updated if the ontology changes. It is therefore safe to apply changes to
      *         this ontology while iterating over this set.
-     * @deprecated use the stream method
+     * @deprecated use {@link #importsDeclarations()}
      */
     @Deprecated
     default Set<OWLImportsDeclaration> getImportsDeclarations() {
@@ -287,7 +287,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      * @return A set containing the axioms which are of the specified type. The set that is returned
      *         is a copy of the axioms in the ontology (and its imports closure) - it will not be
      *         updated if the ontology changes.
-     * @deprecated use the stream method
+     * @deprecated use {@link #tboxAxioms(Imports includeImportsClosure)}
      */
     @Deprecated
     default Set<OWLAxiom> getTBoxAxioms(Imports includeImportsClosure) {
@@ -313,7 +313,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      * @return A set containing the axioms which are of the specified type. The set that is returned
      *         is a copy of the axioms in the ontology (and its imports closure) - it will not be
      *         updated if the ontology changes.
-     * @deprecated use the stream method
+     * @deprecated use {@link #aboxAxioms(Imports includeImportsClosure)}
      */
     @Deprecated
     default Set<OWLAxiom> getABoxAxioms(Imports includeImportsClosure) {
@@ -339,7 +339,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      * @return A set containing the axioms which are of the specified type. The set that is returned
      *         is a copy of the axioms in the ontology (and its imports closure) - it will not be
      *         updated if the ontology changes.
-     * @deprecated use the stream method
+     * @deprecated use {@link #rboxAxioms(Imports includeImportsClosure)}
      */
     @Deprecated
     default Set<OWLAxiom> getRBoxAxioms(Imports includeImportsClosure) {
@@ -368,7 +368,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      * @return The set that is returned is a copy of the axioms in the ontology - it will not be
      *         updated if the ontology changes. It is therefore safe to apply changes to this
      *         ontology while iterating over this set.
-     * @deprecated use the stream method
+     * @deprecated use {@link #generalClassAxioms()}
      */
     @Deprecated
     default Set<OWLClassAxiom> getGeneralClassAxioms() {
@@ -406,7 +406,7 @@ public interface OWLOntology extends OWLObject, HasAnnotations, HasDirectImports
      * @see #getObjectPropertiesInSignature()
      * @see #getDataPropertiesInSignature()
      * @see #getIndividualsInSignature()
-     * @deprecated use the stream method
+     * @deprecated use {@link #signature(Imports imports)}
      */
     @Deprecated
     default Set<OWLEntity> getSignature(Imports imports) {


### PR DESCRIPTION
This issue is purely a Javadoc one but, for me at least, greatly improves the utility of the Javadoc for guiding developers towards the `Stream` methods explicitly. 

Right now I've only updated `OWLOntology` but the following files could also be improved
```
./api/src/main/java/org/semanticweb/owlapi/model/OWLAxiomCollectionBooleanArgs.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLDisjointUnionAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/HasAxioms.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLObject.java
./api/src/main/java/org/semanticweb/owlapi/model/HasClassesInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLNaryClassAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/HasAxiomsByType.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLAxiomIndex.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLSignatureBooleanArgs.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLAxiomCollection.java
./api/src/main/java/org/semanticweb/owlapi/model/HasAnnotationPropertiesInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLNaryPropertyAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/HasGetOntologies.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLNaryIndividualAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLOntologyManager.java
./api/src/main/java/org/semanticweb/owlapi/model/HasSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/HasImportsClosure.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLEquivalentClassesAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLObjectOneOf.java
./api/src/main/java/org/semanticweb/owlapi/model/HasObjectPropertiesInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLDatatypeRestriction.java
./api/src/main/java/org/semanticweb/owlapi/model/HasAnnotations.java
./api/src/main/java/org/semanticweb/owlapi/model/HasIndividualsInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/HasDatatypesInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/HasGetEntitiesInSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLSignature.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLHasKeyAxiom.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLNaryDataRange.java
./api/src/main/java/org/semanticweb/owlapi/model/SWRLAtom.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLDataOneOf.java
./api/src/main/java/org/semanticweb/owlapi/model/HasLogicalAxioms.java
./api/src/main/java/org/semanticweb/owlapi/model/HasDirectImports.java
./api/src/main/java/org/semanticweb/owlapi/model/OWLNaryBooleanClassExpression.java
./api/src/main/java/org/semanticweb/owlapi/model/HasDataPropertiesInSignature.java
```

If you agree with me on this improvement, then I can extend it to the remaining files. 