### PR TITLE
owlapi-api (v6): changes in model

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLClassExpression.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLClassExpression.java
@@ -22,7 +22,7 @@ import java.util.stream.Stream;
  * @author Matthew Horridge The University Of Manchester Bio-Health Informatics Group
  * @since 2.0.0
  */
-public interface OWLClassExpression extends OWLObject, OWLPropertyRange, SWRLPredicate, AsOWLClass {
+public interface OWLClassExpression extends OWLObject, OWLPropertyRange, OWLPropertyDomain, SWRLPredicate, AsOWLClass {
 
     /**
      * Gets the class expression type for this class expression.

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLDataPropertyDomainAxiom.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLDataPropertyDomainAxiom.java
@@ -20,7 +20,7 @@ package org.semanticweb.owlapi6.model;
  * @since 2.0.0
  */
 public interface OWLDataPropertyDomainAxiom
-    extends OWLPropertyDomainAxiom<OWLDataPropertyExpression>, OWLDataPropertyAxiom {
+    extends OWLPropertyDomainAxiom<OWLDataPropertyExpression, OWLClassExpression>, OWLDataPropertyAxiom {
 
     @Override
     @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLObjectPropertyDomainAxiom.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLObjectPropertyDomainAxiom.java
@@ -20,7 +20,7 @@ package org.semanticweb.owlapi6.model;
  * @since 2.0.0
  */
 public interface OWLObjectPropertyDomainAxiom extends
-    OWLPropertyDomainAxiom<OWLObjectPropertyExpression>, OWLObjectPropertyAxiom {
+    OWLPropertyDomainAxiom<OWLObjectPropertyExpression, OWLClassExpression>, OWLObjectPropertyAxiom {
 
     @Override
     @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyDomain.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyDomain.java
@@ -13,7 +13,7 @@
 package org.semanticweb.owlapi6.model;
 
 /**
- * A marker interface, for objects that can be the ranges of properties.
+ * A marker interface, for objects that can be the domains of {@link OWLObjectPropertyExpression object} or {@link OWLDataPropertyExpression data} properties.
  *
  * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
  * @since 2.0.0

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyDomainAxiom.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyDomainAxiom.java
@@ -13,16 +13,15 @@
 package org.semanticweb.owlapi6.model;
 
 /**
- * Represents
- * <a href="http://www.w3.org/TR/owl2-syntax/#Object_Property_Domain">
- * ObjectPropertyDomain</a> axioms in the OWL 2 specification.
+ * Represents <a href="http://www.w3.org/TR/owl2-syntax/#Object_Property_Domain">
+ * ObjectPropertyDomain</a> and <a href="https://www.w3.org/TR/owl2-syntax/#Data_Property_Domain">
+ * Data Property Domain</a> axioms in the OWL 2 specification.
  *
- * @param <P>
- *        property expression
- * @author Matthew Horridge, The University Of Manchester, Bio-Health
- *         Informatics Group
+ * @param <P> {@link OWLPropertyExpression property expression}
+ * @param <R> {@link OWLPropertyDomain domain}
+ * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
  * @since 2.0.0
  */
-public interface OWLPropertyDomainAxiom<P extends OWLPropertyExpression>
-    extends OWLUnaryPropertyAxiom<P>, OWLSubClassOfAxiomShortCut, HasDomain<OWLClassExpression> {
+public interface OWLPropertyDomainAxiom<P extends OWLPropertyExpression, R extends OWLPropertyDomain>
+    extends OWLUnaryPropertyAxiom<P>, OWLSubClassOfAxiomShortCut, HasDomain<R> {
 }

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyRange.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyRange.java
@@ -13,7 +13,7 @@
 package org.semanticweb.owlapi6.model;
 
 /**
- * A marker interface, for objects that can be the ranges of properties.
+ * A marker interface, for objects that can be the ranges of {@link OWLObjectPropertyExpression object} or {@link OWLDataPropertyExpression data} properties.
  *
  * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
  * @since 2.0.0

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyRangeAxiom.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLPropertyRangeAxiom.java
@@ -13,15 +13,13 @@
 package org.semanticweb.owlapi6.model;
 
 /**
- * Represents <a href="http://www.w3.org/TR/owl2-syntax/#Object_Property_Range">
- * ObjectPropertyRange</a> axioms in the OWL 2 specification.
+ * Represents <a href="http://www.w3.org/TR/owl2-syntax/#Object_Property_Range">ObjectPropertyRange</a>
+ * and <a href="https://www.w3.org/TR/owl2-syntax/#Data_Property_Range">
+ * Data Property Range</a> axioms in the OWL 2 specification.
  *
- * @param <R>
- *        range
- * @param <P>
- *        property expression
- * @author Matthew Horridge, The University Of Manchester, Bio-Health
- *         Informatics Group
+ * @param <R> {@link OWLPropertyRange range}
+ * @param <P> {@link OWLPropertyExpression property expression}
+ * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
  * @since 2.0.0
  */
 public interface OWLPropertyRangeAxiom<P extends OWLPropertyExpression, R extends OWLPropertyRange>

--- a/api/src/main/java/org/semanticweb/owlapi6/model/OWLSubAnnotationPropertyOfAxiom.java
+++ b/api/src/main/java/org/semanticweb/owlapi6/model/OWLSubAnnotationPropertyOfAxiom.java
@@ -19,7 +19,7 @@ package org.semanticweb.owlapi6.model;
  * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
  */
-public interface OWLSubAnnotationPropertyOfAxiom extends OWLAnnotationAxiom {
+public interface OWLSubAnnotationPropertyOfAxiom extends OWLSubPropertyAxiom<OWLAnnotationProperty>, OWLAnnotationAxiom {
 
     @Override
     @SuppressWarnings("unchecked")
@@ -29,20 +29,6 @@ public interface OWLSubAnnotationPropertyOfAxiom extends OWLAnnotationAxiom {
     default OWLObjectType type() {
         return OWLObjectType.SUB_ANNOTATION;
     }
-
-    /**
-     * Gets the subproperty of this axiom.
-     *
-     * @return The annotation property that represents the subproperty in this axiom.
-     */
-    OWLAnnotationProperty getSubProperty();
-
-    /**
-     * Gets the super property of this axiom.
-     *
-     * @return The annotation property that represents the super property in this axiom.
-     */
-    OWLAnnotationProperty getSuperProperty();
 
     @Override
     default void accept(OWLObjectVisitor visitor) {

--- a/impl/src/main/java/org/semanticweb/owlapi6/impl/OWLPropertyDomainAxiomImpl.java
+++ b/impl/src/main/java/org/semanticweb/owlapi6/impl/OWLPropertyDomainAxiomImpl.java
@@ -12,14 +12,14 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi6.impl;
 
-import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.checkNotNull;
-
-import java.util.Collection;
-
 import org.semanticweb.owlapi6.model.OWLAnnotation;
 import org.semanticweb.owlapi6.model.OWLClassExpression;
 import org.semanticweb.owlapi6.model.OWLPropertyDomainAxiom;
 import org.semanticweb.owlapi6.model.OWLPropertyExpression;
+
+import java.util.Collection;
+
+import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.checkNotNull;
 
 /**
  * @author Matthew Horridge, The University Of Manchester, Bio-Health Informatics Group
@@ -27,7 +27,7 @@ import org.semanticweb.owlapi6.model.OWLPropertyExpression;
  * @param <P> property type
  */
 public abstract class OWLPropertyDomainAxiomImpl<P extends OWLPropertyExpression>
-                extends OWLUnaryPropertyAxiomImpl<P> implements OWLPropertyDomainAxiom<P> {
+                extends OWLUnaryPropertyAxiomImpl<P> implements OWLPropertyDomainAxiom<P, OWLClassExpression> {
 
     private final OWLClassExpression domain;
 

--- a/otherformats/src/main/java/org/semanticweb/owlapi6/dlsyntax/renderer/DLSyntaxObjectRenderer.java
+++ b/otherformats/src/main/java/org/semanticweb/owlapi6/dlsyntax/renderer/DLSyntaxObjectRenderer.java
@@ -12,132 +12,23 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi6.dlsyntax.renderer;
 
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.AND;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.BOTTOM;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.COMMA;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.COMP;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.DISJOINT_WITH;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.EQUAL;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.EQUIVALENT_TO;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.EXISTS;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.FORALL;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.IMPLIES;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.IN;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.INVERSE;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.MAX;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.MIN;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.NOT;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.NOT_EQUAL;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.OR;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.SELF;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.SUBCLASS;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.TOP;
-import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.WEDGE;
-import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.checkNotNull;
-import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.verifyNotNull;
-
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-
-import javax.annotation.Nullable;
-
 import org.semanticweb.owlapi6.annotations.Renders;
 import org.semanticweb.owlapi6.formats.DLSyntaxDocumentFormat;
 import org.semanticweb.owlapi6.io.OWLObjectRenderer;
-import org.semanticweb.owlapi6.model.IRI;
-import org.semanticweb.owlapi6.model.IsAnonymous;
-import org.semanticweb.owlapi6.model.OWLAsymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLCardinalityRestriction;
-import org.semanticweb.owlapi6.model.OWLClass;
-import org.semanticweb.owlapi6.model.OWLClassAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLClassExpression;
-import org.semanticweb.owlapi6.model.OWLDataAllValuesFrom;
-import org.semanticweb.owlapi6.model.OWLDataComplementOf;
-import org.semanticweb.owlapi6.model.OWLDataExactCardinality;
-import org.semanticweb.owlapi6.model.OWLDataHasValue;
-import org.semanticweb.owlapi6.model.OWLDataIntersectionOf;
-import org.semanticweb.owlapi6.model.OWLDataMaxCardinality;
-import org.semanticweb.owlapi6.model.OWLDataMinCardinality;
-import org.semanticweb.owlapi6.model.OWLDataOneOf;
-import org.semanticweb.owlapi6.model.OWLDataProperty;
-import org.semanticweb.owlapi6.model.OWLDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLDataPropertyDomainAxiom;
-import org.semanticweb.owlapi6.model.OWLDataPropertyRangeAxiom;
-import org.semanticweb.owlapi6.model.OWLDataSomeValuesFrom;
-import org.semanticweb.owlapi6.model.OWLDataUnionOf;
-import org.semanticweb.owlapi6.model.OWLDatatype;
-import org.semanticweb.owlapi6.model.OWLDatatypeRestriction;
-import org.semanticweb.owlapi6.model.OWLDifferentIndividualsAxiom;
-import org.semanticweb.owlapi6.model.OWLDisjointClassesAxiom;
-import org.semanticweb.owlapi6.model.OWLDisjointDataPropertiesAxiom;
-import org.semanticweb.owlapi6.model.OWLDisjointObjectPropertiesAxiom;
-import org.semanticweb.owlapi6.model.OWLDisjointUnionAxiom;
-import org.semanticweb.owlapi6.model.OWLEntity;
-import org.semanticweb.owlapi6.model.OWLEquivalentClassesAxiom;
-import org.semanticweb.owlapi6.model.OWLEquivalentDataPropertiesAxiom;
-import org.semanticweb.owlapi6.model.OWLEquivalentObjectPropertiesAxiom;
-import org.semanticweb.owlapi6.model.OWLFacetRestriction;
-import org.semanticweb.owlapi6.model.OWLFunctionalDataPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLHasValueRestriction;
-import org.semanticweb.owlapi6.model.OWLInverseFunctionalObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLInverseObjectPropertiesAxiom;
-import org.semanticweb.owlapi6.model.OWLIrreflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLLiteral;
-import org.semanticweb.owlapi6.model.OWLLogicalAxiom;
-import org.semanticweb.owlapi6.model.OWLNamedIndividual;
-import org.semanticweb.owlapi6.model.OWLNegativeDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLNegativeObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLObject;
-import org.semanticweb.owlapi6.model.OWLObjectAllValuesFrom;
-import org.semanticweb.owlapi6.model.OWLObjectComplementOf;
-import org.semanticweb.owlapi6.model.OWLObjectExactCardinality;
-import org.semanticweb.owlapi6.model.OWLObjectHasSelf;
-import org.semanticweb.owlapi6.model.OWLObjectHasValue;
-import org.semanticweb.owlapi6.model.OWLObjectIntersectionOf;
-import org.semanticweb.owlapi6.model.OWLObjectInverseOf;
-import org.semanticweb.owlapi6.model.OWLObjectMaxCardinality;
-import org.semanticweb.owlapi6.model.OWLObjectMinCardinality;
-import org.semanticweb.owlapi6.model.OWLObjectOneOf;
-import org.semanticweb.owlapi6.model.OWLObjectProperty;
-import org.semanticweb.owlapi6.model.OWLObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLObjectPropertyDomainAxiom;
-import org.semanticweb.owlapi6.model.OWLObjectPropertyRangeAxiom;
-import org.semanticweb.owlapi6.model.OWLObjectSomeValuesFrom;
-import org.semanticweb.owlapi6.model.OWLObjectUnionOf;
-import org.semanticweb.owlapi6.model.OWLObjectVisitor;
-import org.semanticweb.owlapi6.model.OWLOntology;
-import org.semanticweb.owlapi6.model.OWLPropertyAssertionAxiom;
-import org.semanticweb.owlapi6.model.OWLPropertyDomainAxiom;
-import org.semanticweb.owlapi6.model.OWLPropertyExpression;
-import org.semanticweb.owlapi6.model.OWLPropertyRange;
-import org.semanticweb.owlapi6.model.OWLPropertyRangeAxiom;
-import org.semanticweb.owlapi6.model.OWLQuantifiedRestriction;
-import org.semanticweb.owlapi6.model.OWLReflexiveObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLSameIndividualAxiom;
-import org.semanticweb.owlapi6.model.OWLSubClassOfAxiom;
-import org.semanticweb.owlapi6.model.OWLSubDataPropertyOfAxiom;
-import org.semanticweb.owlapi6.model.OWLSubObjectPropertyOfAxiom;
-import org.semanticweb.owlapi6.model.OWLSubPropertyChainOfAxiom;
-import org.semanticweb.owlapi6.model.OWLSymmetricObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.OWLTransitiveObjectPropertyAxiom;
-import org.semanticweb.owlapi6.model.PrefixManager;
-import org.semanticweb.owlapi6.model.SWRLBuiltInAtom;
-import org.semanticweb.owlapi6.model.SWRLClassAtom;
-import org.semanticweb.owlapi6.model.SWRLDataPropertyAtom;
-import org.semanticweb.owlapi6.model.SWRLDataRangeAtom;
-import org.semanticweb.owlapi6.model.SWRLDifferentIndividualsAtom;
-import org.semanticweb.owlapi6.model.SWRLIndividualArgument;
-import org.semanticweb.owlapi6.model.SWRLLiteralArgument;
-import org.semanticweb.owlapi6.model.SWRLObjectPropertyAtom;
-import org.semanticweb.owlapi6.model.SWRLRule;
-import org.semanticweb.owlapi6.model.SWRLSameIndividualAtom;
-import org.semanticweb.owlapi6.model.SWRLVariable;
+import org.semanticweb.owlapi6.model.*;
 import org.semanticweb.owlapi6.utilities.IRIShortFormProvider;
 import org.semanticweb.owlapi6.utilities.ShortFormProvider;
 import org.semanticweb.owlapi6.utility.SimpleIRIShortFormProvider;
 import org.semanticweb.owlapi6.utility.SimpleShortFormProvider;
+
+import javax.annotation.Nullable;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.semanticweb.owlapi6.dlsyntax.renderer.DLSyntax.*;
+import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.checkNotNull;
+import static org.semanticweb.owlapi6.utilities.OWLAPIPreconditions.verifyNotNull;
 
 /**
  * Renders objects in unicode DL syntax.
@@ -301,7 +192,7 @@ public class DLSyntaxObjectRenderer implements OWLObjectRenderer, OWLObjectVisit
         return writeSpace().write(SUBCLASS).writeSpace();
     }
 
-    private void writeDomainAxiom(OWLPropertyDomainAxiom<?> axiom) {
+    private void writeDomainAxiom(OWLPropertyDomainAxiom<?, ?> axiom) {
         write(EXISTS).writeSpace().accept(axiom.getProperty()).writeRestrictionSeparator()
             .write(TOP).subClass().roundedAnon(axiom.getDomain());
     }


### PR DESCRIPTION
This commit is only for **v6** since same changes in **v5** may affect existing client code (if someone uses `OWLPropertyDomainAxiom` abstraction directly, then changes in generic types will lead to a compilation error). 
I think it is safe for v6, since no one is using v6 yet.
For v5 there is another PR https://github.com/owlcs/owlapi/pull/980

the patch contains two things: 
- `org.semanticweb.owlapi6.model.OWLPropertyDomain` has been out of use, it is fixed: `OWLPropertyDomainAxiom` has now two generic params
- `org.semanticweb.owlapi6.model.OWLSubAnnotationPropertyOfAxiom` is extending `OWLSubPropertyAxiom` (for reasons of uniformity)
