### PR TITLE
Fix unclosed gzip stream

### DIFF
--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImpl.java
@@ -354,28 +354,30 @@ public class OWLLiteralImpl extends OWLObjectImplWithoutEntityAndAnonCaching imp
 
         @Nonnull
         static byte[] compress(String s) throws IOException {
-            ByteArrayOutputStream out = new ByteArrayOutputStream();
-            GZIPOutputStream zipout = new GZIPOutputStream(out);
-            Writer writer = new OutputStreamWriter(zipout, COMPRESSED_ENCODING);
-            writer.write(s);
-            writer.flush();
-            zipout.finish();
-            zipout.flush();
-            return out.toByteArray();
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream();
+                    GZIPOutputStream zipout = new GZIPOutputStream(out);) {
+                Writer writer = new OutputStreamWriter(zipout, COMPRESSED_ENCODING);
+                writer.write(s);
+                writer.flush();
+                zipout.finish();
+                zipout.flush();
+                return out.toByteArray();
+            }
         }
 
         @Nonnull
         static String decompress(byte[] result) throws IOException {
-            ByteArrayInputStream in = new ByteArrayInputStream(result);
-            GZIPInputStream zipin = new GZIPInputStream(in);
-            Reader reader = new InputStreamReader(zipin, COMPRESSED_ENCODING);
-            StringBuilder b = new StringBuilder();
-            int c = reader.read();
-            while (c > -1) {
-                b.append((char) c);
-                c = reader.read();
+            try (ByteArrayInputStream in = new ByteArrayInputStream(result);
+                    GZIPInputStream zipin = new GZIPInputStream(in);) {
+                Reader reader = new InputStreamReader(zipin, COMPRESSED_ENCODING);
+                StringBuilder b = new StringBuilder();
+                int c = reader.read();
+                while (c > -1) {
+                    b.append((char) c);
+                    c = reader.read();
+                }
+                return b.toString();
             }
-            return b.toString();
         }
 
         private static final String COMPRESSED_ENCODING = "UTF-16";


### PR DESCRIPTION
Unclosed GZIPInputStream and GZIPOutputStream cause native memory leak. The fix is to make sure to close the GZIP streams after reading or writing to.

This is statistics collected by jemmaloc showing the deflateInit2_ consume 41.3% of mem.

Total: 5791.1 MB
  2830.6  48.9%  48.9%   2830.6  48.9% os::malloc@928ef0
  2393.1  41.3%  90.2%   2393.1  41.3% deflateInit2_
   304.2   5.3%  95.5%    304.2   5.3% inflateInit2_
   171.2   3.0%  98.4%    171.2   3.0% updatewindow
    76.6   1.3%  99.7%     76.6   1.3% readCEN
     4.8   0.1%  99.8%      4.8   0.1% init
     4.0   0.1%  99.9%    308.2   5.3% Java_java_util_zip_Inflater_init
     3.0   0.1%  99.9%      3.0   0.1% JLI_MemAlloc
     2.5   0.0% 100.0%      2.5   0.0% newEntry
     1.1   0.0% 100.0%   2394.3  41.3% Java_java_util_zip_Deflater_init
     0.0   0.0% 100.0%    206.9   3.6% 0x00007fd9dd36e706
    
![jemalloc](https://user-images.githubusercontent.com/20343042/100791486-2b706d80-33ce-11eb-8314-d14ebaecf809.jpg)


