### PR TITLE
Upgraded to RDF4j 3.7.4 and fixed issues with OSGi bundles

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -34,6 +34,8 @@
 		<dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>1.7.22</version></dependency>
 		<dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><version>1.7.22</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model-api</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model-vocabulary</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-api</artifactId><version>${inherited.rdf4j.version}</version>
 			<exclusions>
 				<exclusion>
@@ -93,7 +95,7 @@
 						</_exportcontents>
 						<Import-Package>
 							!sun.misc,
-							org.eclipse.rdf4j.*;version="[2.0,3.0)",
+							org.eclipse.rdf4j.*;version="[3.0,4.0)",
 							!javax.annotation,
 							!com.google.inject.internal.*;resolution:=optional,
 							!com.github.jsonldjava.shaded.com.google.common.collect.*;resolution:=optional,

--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -34,6 +34,8 @@
 		<dependency><groupId>org.slf4j</groupId><artifactId>slf4j-api</artifactId><version>1.7.30</version></dependency>
 		<dependency><groupId>org.slf4j</groupId><artifactId>jcl-over-slf4j</artifactId><version>1.7.30</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model-api</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-model-vocabulary</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-api</artifactId><version>${inherited.rdf4j.version}</version>
 			<exclusions>
 				<exclusion>
@@ -64,7 +66,7 @@
 		<dependency><groupId>commons-logging</groupId><artifactId>commons-logging</artifactId><version>1.2</version></dependency>
 		<dependency><groupId>commons-io</groupId><artifactId>commons-io</artifactId><version>2.7</version></dependency>
 		<dependency><groupId>com.github.vsonnier</groupId><artifactId>hppcrt</artifactId><version>0.7.5</version></dependency>
-		<dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>30.0-jre</version></dependency>
+		<dependency><groupId>com.google.guava</groupId><artifactId>guava</artifactId><version>30.1.1-jre</version></dependency>
 		<dependency><groupId>com.github.ben-manes.caffeine</groupId><artifactId>caffeine</artifactId><version>2.8.6</version></dependency>
 		<!--  Disable until updated to use RDF4J
 		<dependency><groupId>org.semarglproject</groupId><artifactId>semargl-sesame</artifactId><version>0.7</version></dependency>
@@ -143,8 +145,9 @@
 							!org.checkerframework.*,
 							net.sf.ehcache.*;resolution:=optional,
 							net.spy.memcached.*;resolution:=optional,
-							com.google.common.base;version=30.0.0.jre;resolution:=optional,
-							com.google.common.collect;version=30.0.0.jre;resolution:=optional,
+							com.google.common.base;version=30.1.1.jre;resolution:=optional,
+							com.google.common.collect;version=30.1.1.jre;resolution:=optional,
+							com.google.common.hash;version=30.1.1.jre;resolution:=optional,
 							javax.inject;version="[1.0,2)",
 							javax.annotation;version=!,
 							*

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<!-- Specify the encoding of the source files. -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<rdf4j.version>3.4.3</rdf4j.version>
+		<rdf4j.version>3.7.4</rdf4j.version>
 		<!-- remove this line for releases, if the release process fails because 
 			of missing javadoc jars -->
 		<no-javadoc>false</no-javadoc>
@@ -103,7 +103,7 @@
 		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
-			<version>30.0-jre</version>
+			<version>30.1.1-jre</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.code.findbugs</groupId>

--- a/rio/pom.xml
+++ b/rio/pom.xml
@@ -29,6 +29,16 @@
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-model-api</artifactId>
+			<version>${inherited.rdf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
+			<artifactId>rdf4j-model-vocabulary</artifactId>
+			<version>${inherited.rdf4j.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.rdf4j</groupId>
 			<artifactId>rdf4j-rio-api</artifactId>
 			<version>${inherited.rdf4j.version}</version>
 			<exclusions>


### PR DESCRIPTION
- Upgraded to latest RDF4j version (3.7.4)
- Fixed OSGi bundle import version issue where it was requiring 2.x version of RDF4j