### PR TITLE
Disable the default builds report generation function

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,8 @@
 		<no-javadoc>false</no-javadoc>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<!-- 5.0.0 is the earliest release on Maven Central for this series -->
-		<last.japicmp.compare.version>5.0.0</last.japicmp.compare.version>		
+		<last.japicmp.compare.version>5.0.0</last.japicmp.compare.version>
+		<closeTestReports>true</closeTestReports>		
 	</properties>
 
 
@@ -352,6 +353,7 @@
 					<argLine>-Xmx2G -Djava.awt.headless=true</argLine>
 					<parallel>classes</parallel>
 					<useUnlimitedThreads>true</useUnlimitedThreads>
+					<disableXmlReport>${closeTestReports}</disableXmlReport>
 
 				</configuration>
 			</plugin>


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
