### PR TITLE
Extension of Manchester syntax to cover the whole of OWL2 DL

### DIFF
--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserErrorsTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserErrorsTestCase.java
@@ -38,6 +38,8 @@ class ManchesterOWLSyntaxParserErrorsTestCase extends TestBase {
     void setUp() {
         OWLClass cls = mock(OWLClass.class);
         when(entityChecker.getOWLClass("C")).thenReturn(cls);
+        when(cls.isOWLClass()).thenReturn(true);
+        when(cls.asOWLClass()).thenReturn(cls);
         OWLClass clsC1 = mock(OWLClass.class);
         when(entityChecker.getOWLClass("C1")).thenReturn(clsC1);
         OWLObjectProperty oP = mock(OWLObjectProperty.class);

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
@@ -217,8 +217,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
     protected final DefaultPrefixManager pm = new DefaultPrefixManager();
     protected final Set<ManchesterOWLSyntax> potentialKeywords = new HashSet<>();
     private final List<Token> tokens = new ArrayList<>();
-    private final Map<ManchesterOWLSyntax, AnnAxiom<OWLClass, ?>> classFrameSections =
-        new EnumMap<>(ManchesterOWLSyntax.class);
+    private final Map<ManchesterOWLSyntax, AnnAxiom<OWLClass, ?>> simpleClassFrameSections =
+            new EnumMap<>(ManchesterOWLSyntax.class);
+    private final Map<ManchesterOWLSyntax, AnnAxiom<OWLClassExpression, ?>> complexClassFrameSections =
+            new EnumMap<>(ManchesterOWLSyntax.class);
     private final Map<String, SWRLBuiltInsVocabulary> ruleBuiltIns = new TreeMap<>();
     private final Map<ManchesterOWLSyntax, AnnAxiom<OWLDataProperty, ?>> dataPropertyFrameSections =
         new EnumMap<>(ManchesterOWLSyntax.class);
@@ -361,16 +363,16 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
 
     private void initialiseClassFrameSections() {
         //@formatter:off
-        initialiseSection(new AnnAxiom<OWLClass, OWLAnnotation>(x -> parseAnnotation(), ANNOTATIONS, (s, o, anns) -> df.getOWLAnnotationAssertionAxiom(s.getIRI(), o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, OWLClassExpression>(x -> parseUnion(), SUBCLASS_OF, (s, o, anns) -> df.getOWLSubClassOfAxiom(s, o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, OWLClassExpression>(x -> parseUnion(), EQUIVALENT_TO, (s, o, anns) -> df.getOWLEquivalentClassesAxiom(s, o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, OWLClassExpression>(x -> parseUnion(), DISJOINT_WITH, (s, o, anns) -> df.getOWLDisjointClassesAxiom(s, o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, Set<OWLPropertyExpression>>(x -> parsePropertyList(), HAS_KEY, (s, o, anns) -> df.getOWLHasKeyAxiom(s, o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, Set<OWLClassExpression>>(x -> parseClassExpressionList(), DISJOINT_UNION_OF, (s, o, anns) -> df.getOWLDisjointUnionAxiom(s, o, anns)), classFrameSections);
+        initialiseSection(new AnnAxiom<OWLClass, OWLAnnotation>(x -> parseAnnotation(), ANNOTATIONS, (s, o, anns) -> df.getOWLAnnotationAssertionAxiom(s.getIRI(), o, anns)), simpleClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClass, Set<OWLClassExpression>>(x -> parseClassExpressionList(), DISJOINT_UNION_OF, (s, o, anns) -> df.getOWLDisjointUnionAxiom(s, o, anns)), simpleClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, OWLClassExpression>(x -> parseUnion(), SUBCLASS_OF, (s, o, anns) -> df.getOWLSubClassOfAxiom(s, o, anns)), complexClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, OWLClassExpression>(x -> parseUnion(), EQUIVALENT_TO, (s, o, anns) -> df.getOWLEquivalentClassesAxiom(s, o, anns)), complexClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, OWLClassExpression>(x -> parseUnion(), DISJOINT_WITH, (s, o, anns) -> df.getOWLDisjointClassesAxiom(s, o, anns)), complexClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, Set<OWLPropertyExpression>>(x -> parsePropertyList(), HAS_KEY, (s, o, anns) -> df.getOWLHasKeyAxiom(s, o, anns)), complexClassFrameSections);
         // Extensions
-        initialiseSection(new AnnAxiom<OWLClass, OWLClassExpression>(x -> parseUnion(), SUPERCLASS_OF, (s, o, anns) -> df.getOWLSubClassOfAxiom(o, s, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, Set<OWLClassExpression>>(x -> parseClassExpressionList(), DISJOINT_CLASSES, (s, o, anns) -> df.getOWLDisjointClassesAxiom(o, anns)), classFrameSections);
-        initialiseSection(new AnnAxiom<OWLClass, OWLIndividual>(x -> parseIndividual(), INDIVIDUALS, (s, o, anns) -> df.getOWLClassAssertionAxiom(s, o, anns)), classFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, OWLClassExpression>(x -> parseUnion(), SUPERCLASS_OF, (s, o, anns) -> df.getOWLSubClassOfAxiom(o, s, anns)), complexClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, Set<OWLClassExpression>>(x -> parseClassExpressionList(), DISJOINT_CLASSES, (s, o, anns) -> df.getOWLDisjointClassesAxiom(o, anns)), complexClassFrameSections);
+        initialiseSection(new AnnAxiom<OWLClassExpression, OWLIndividual>(x -> parseIndividual(), INDIVIDUALS, (s, o, anns) -> df.getOWLClassAssertionAxiom(s, o, anns)), complexClassFrameSections);
         //@formatter:on
     }
 
@@ -1140,7 +1142,7 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
                 potentialKeywords.clear();
                 resetPossible(possible);
                 axioms.addAll(parseClassFrame());
-                possible.addAll(classFrameSections.keySet());
+                possible.addAll(simpleClassFrameSections.keySet());
             } else if (OBJECT_PROPERTY.matches(tok)) {
                 potentialKeywords.clear();
                 resetPossible(possible);
@@ -1192,10 +1194,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!DATATYPE.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(DATATYPE).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLDatatype datatype = getOWLDatatype(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
-        axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(datatype)));
+        axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(datatype, annotations)));
         while (true) {
             String sect = peekToken();
             if (EQUIVALENT_TO.matches(sect)) {
@@ -1343,11 +1347,26 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!CLASS.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(CLASS).build();
         }
-        String subj = consumeToken();
-        OWLClass cls = getOWLClass(subj);
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
+
+        OWLClassExpression cls;
+        if (annotations.isEmpty()) {
+            cls = parseUnion();
+        } else {
+            String sub = consumeToken();
+            cls = getOWLClass(sub);
+        }
+
+
         Set<OntologyAxiomPair> axioms = new HashSet<>();
-        axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(cls)));
-        parseFrameSections(eof, axioms, cls, classFrameSections);
+
+        if (cls.isOWLClass()) {
+            axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(cls.asOWLClass(), annotations)));
+            parseFrameSections(eof, axioms, cls.asOWLClass(), simpleClassFrameSections);
+        }
+
+        parseFrameSections(eof, axioms, cls, complexClassFrameSections);
         return axioms;
     }
 
@@ -1435,11 +1454,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
     private Set<OntologyAxiomPair> parseObjectPropertyFrame(boolean eof) {
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         consumeToken(OBJECT_PROPERTY);
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String token = consumeToken();
         OWLObjectProperty prop = getOWLObjectProperty(token);
         if (!prop.isAnonymous()) {
             axioms.add(new OntologyAxiomPair(defaultOntology,
-                df.getOWLDeclarationAxiom(prop.asOWLObjectProperty())));
+                df.getOWLDeclarationAxiom(prop.asOWLObjectProperty(), annotations)));
         }
         parseFrameSections(eof, axioms, prop, objectPropertyFrameSections);
         return axioms;
@@ -1451,10 +1471,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!DATA_PROPERTY.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(DATA_PROPERTY).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLDataProperty prop = getOWLDataProperty(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
-        axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(prop)));
+        axioms.add(new OntologyAxiomPair(defaultOntology, df.getOWLDeclarationAxiom(prop, annotations)));
         parseFrameSections(false, axioms, prop, dataPropertyFrameSections);
         return axioms;
     }
@@ -1465,11 +1487,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!ANNOTATION_PROPERTY.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(ANNOTATION_PROPERTY).build();
         }
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLAnnotationProperty prop = getOWLAnnotationProperty(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         for (OWLOntology ont : getOntologies()) {
-            axioms.add(new OntologyAxiomPair(ont, df.getOWLDeclarationAxiom(prop)));
+            axioms.add(new OntologyAxiomPair(ont, df.getOWLDeclarationAxiom(prop, annotations)));
         }
         parseFrameSections(false, axioms, prop, annotationPropertyFrameSections);
         return axioms;
@@ -1481,12 +1504,13 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!INDIVIDUAL.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(INDIVIDUAL).build();
         }
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLIndividual ind = getOWLIndividual(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         if (!ind.isAnonymous()) {
             axioms.add(new OntologyAxiomPair(getOntology(null),
-                df.getOWLDeclarationAxiom(ind.asOWLNamedIndividual())));
+                df.getOWLDeclarationAxiom(ind.asOWLNamedIndividual(), annotations)));
         }
         parseFrameSections(false, axioms, ind, individualFrameSections);
         return axioms;
@@ -2098,16 +2122,40 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         return IRI.create(iriString.substring(1, iriString.length() - 1));
     }
 
+    private int skipAnnotationsProcessDeclaredEntities(int start) {
+        if (start < tokens.size()) {
+            String nameToken = tokens.get(start).getToken();
+            if(ANNOTATIONS.matches(nameToken)) {
+                do {
+                    start = skipAnnotationsProcessDeclaredEntities(start + 1) + 2;
+                    nameToken = tokens.get(start).getToken();
+                } while (start < tokens.size() && (ANNOTATIONS.matches(nameToken) || COMMA.matches(nameToken)));
+            }
+        }
+
+        return start;
+    }
+
     private void processDeclaredEntities() {
+        int j=-1;
         for (int i = 0; i < tokens.size(); i++) {
             String token = tokens.get(i).getToken();
             String name = null;
-            if (i + 1 < tokens.size()) {
-                name = tokens.get(i + 1).getToken();
+            j = skipAnnotationsProcessDeclaredEntities(i + 1);
+            if (j < tokens.size()) {
+                name = tokens.get(j).getToken();
             }
             if (CLASS.matches(token)) {
                 if (name != null) {
-                    classNames.add(name);
+                    if(j + 1 < tokens.size()) {
+                        String nextToken = tokens.get(j + 1).getToken();
+                        ManchesterOWLSyntax a = parse(nextToken);
+                        if(eof(nextToken) || a != null && !(a.isClassExpressionConnectiveKeyword() || a.isClassExpressionQuantiferKeyword())) {
+                            classNames.add(name);
+                        }
+                    } else {
+                        classNames.add(name);
+                    }
                 }
             } else if (OBJECT_PROPERTY.matches(token)) {
                 if (name != null) {

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxFrameRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ManchesterOWLSyntaxFrameRenderer.java
@@ -72,42 +72,14 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nullable;
 
 import org.semanticweb.owlapi.io.OWLRendererException;
 import org.semanticweb.owlapi.manchestersyntax.parser.ManchesterOWLSyntax;
-import org.semanticweb.owlapi.model.AxiomType;
-import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.model.OWLAnnotation;
-import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLAnnotationProperty;
-import org.semanticweb.owlapi.model.OWLAnnotationSubject;
-import org.semanticweb.owlapi.model.OWLAnonymousIndividual;
-import org.semanticweb.owlapi.model.OWLAxiom;
-import org.semanticweb.owlapi.model.OWLClass;
-import org.semanticweb.owlapi.model.OWLClassExpression;
-import org.semanticweb.owlapi.model.OWLDataProperty;
-import org.semanticweb.owlapi.model.OWLDataRange;
-import org.semanticweb.owlapi.model.OWLDatatype;
-import org.semanticweb.owlapi.model.OWLDifferentIndividualsAxiom;
-import org.semanticweb.owlapi.model.OWLEntity;
-import org.semanticweb.owlapi.model.OWLEntityVisitor;
-import org.semanticweb.owlapi.model.OWLEquivalentClassesAxiom;
-import org.semanticweb.owlapi.model.OWLImportsDeclaration;
-import org.semanticweb.owlapi.model.OWLIndividual;
-import org.semanticweb.owlapi.model.OWLNaryPropertyAxiom;
-import org.semanticweb.owlapi.model.OWLNegativeDataPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLNegativeObjectPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLObject;
-import org.semanticweb.owlapi.model.OWLObjectPropertyExpression;
-import org.semanticweb.owlapi.model.OWLOntology;
-import org.semanticweb.owlapi.model.OWLPropertyAssertionAxiom;
-import org.semanticweb.owlapi.model.OWLRuntimeException;
-import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
-import org.semanticweb.owlapi.model.SWRLAtom;
-import org.semanticweb.owlapi.model.SWRLRule;
+import org.semanticweb.owlapi.model.*;
 import org.semanticweb.owlapi.util.CollectionFactory;
 import org.semanticweb.owlapi.util.OWLAxiomFilter;
 import org.semanticweb.owlapi.util.OWLObjectComparator;
@@ -290,6 +262,9 @@ public class ManchesterOWLSyntaxFrameRenderer extends ManchesterOWLSyntaxObjectR
             .forEach(ax -> writeMoreThanTwo(ax, ax.individuals(), SAME_INDIVIDUAL, true));
         o.axioms(AxiomType.SWRL_RULE).sorted(ooc).forEach(
             rule -> writeSection(RULE, Collections.singleton(rule).iterator(), ", ", false));
+        filtersort(o.axioms(AxiomType.SUBCLASS_OF), a -> ((OWLSubClassOfAxiom) a).isGCI())
+                .collect(Collectors.groupingBy(OWLSubClassOfAxiom::getSubClass))
+                .forEach(this::write);
         flush();
     }
 
@@ -455,6 +430,17 @@ public class ManchesterOWLSyntaxFrameRenderer extends ManchesterOWLSyntaxObjectR
 
     protected <T extends OWLAxiom> Stream<T> filtersort(Stream<T> s, Predicate<OWLAxiom> extra) {
         return s.filter(this::isDisplayed).filter(extra).sorted(ooc);
+    }
+
+
+    private void write(OWLClassExpression superClass, List<OWLSubClassOfAxiom> axs) {
+        writeEntityStart(CLASS, superClass);
+
+        if (!isFiltered(AxiomType.SUBCLASS_OF)) {
+            SectionMap<Object, OWLAxiom> superclasses = new SectionMap<>();
+            filtersort(axs.stream()).forEach(ax -> superclasses.put(ax.getSuperClass(), ax));
+            writeSection(SUBCLASS_OF, superclasses, ",", true);
+        }
     }
 
     /**
@@ -942,7 +928,43 @@ public class ManchesterOWLSyntaxFrameRenderer extends ManchesterOWLSyntaxObjectR
         String kw = keyword.toString();
         fireFrameRenderingPrepared(kw);
         writeSection(keyword);
+
+        boolean resetTab = false;
+
+        if(entity instanceof OWLEntity) {
+            Set<OWLAnnotation> annotations = o.declarationAxioms((OWLEntity) entity)
+                    .flatMap(HasAnnotations::annotations)
+                    .sorted()
+                    .collect(Collectors.toSet());
+
+            if (!annotations.isEmpty()) {
+                incrementTab(4);
+                writeNewLine();
+                write(ManchesterOWLSyntax.ANNOTATIONS.toString());
+                write(": ");
+                pushTab(getIndent() + 1);
+                for (Iterator<OWLAnnotation> annoIt = annotations.iterator(); annoIt.hasNext();) {
+                    annoIt.next().accept(this);
+                    if (annoIt.hasNext()) {
+                        write(", ");
+                        writeNewLine();
+                    }
+                }
+                popTab();
+                popTab();
+                incrementTab(2);
+                writeNewLine();
+                resetTab = true;
+            }
+        }
+
         entity.accept(this);
+
+        if(resetTab) {
+            popTab();
+        }
+
+
         fireFrameRenderingStarted(kw);
         writeNewLine();
         incrementTab(4);


### PR DESCRIPTION
Hello,
My name is Björn, and I'm a B.Sc. student of @tillmo. Currently, there are some constructs like general concept inclusions that aren't expressible in Manchester Syntax. As part of my bachelor thesis, I worked out a proposal to extend Manchester Syntax so that all OWL2 DL constructs can be expressed. You can find the excerpt containing the proposed changes [here](https://github.com/owlcs/owlapi/files/8263133/Proposal.pdf).
This pull request contains the proposed changes. What do you think of this proposal? Do you think this syntax extension has a chance to be appreciated by the OWL community?


Currently there are 2 unit tests failing (RelativeIRIsRountTripTestCase.testFormat, AnnotatedPunningTestCase.runTestForAnnotationsOnPunnedEntitiesForFormat). Both use the same IRI for a data property and object property. In my understanding, it is allowed for different entities to have the same IRI, but it is not allowed that two properties of a different kind have the same IRI (mentioned in [the list of new features for OWL2](https://www.w3.org/TR/owl2-new-features/#F12:_Punning)). The latter is the case in both failing cases.