### PR TITLE
OWLOntologyID: change visibility of private fields to protected

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLOntologyID.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLOntologyID.java
@@ -37,15 +37,16 @@ import org.slf4j.LoggerFactory;
  * @author Matthew Horridge, The University of Manchester, Information Management Group
  * @since 3.0.0
  */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 public class OWLOntologyID implements Comparable<OWLOntologyID>, Serializable, IsAnonymous {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OWLOntologyID.class);
     private static final AtomicInteger COUNTER = new AtomicInteger();
     private static final String ANON_PREFIX = "Anonymous-";
-    private transient Optional<String> internalID = emptyOptional();
-    private transient Optional<IRI> ontologyIRI;
-    private transient Optional<IRI> versionIRI;
-    private int hashCode;
+    protected transient Optional<String> internalID = emptyOptional();
+    protected transient Optional<IRI> ontologyIRI;
+    protected transient Optional<IRI> versionIRI;
+    protected int hashCode;
 
     /**
      * Constructs an ontology identifier specifying the ontology IRI and version IRI. Equivalent to


### PR DESCRIPTION
ONTAPI extends this class in order to encapsulate jena Node (see https://github.com/owlcs/ont-api/blob/3.x.x/src/main/java/com/github/owlcs/ontapi/ID.java).
Right now to achieve this purpose we use reflection.
Although that version of `OWLOntologyID` is just a view, using reflection is not good in general.
I think it is better to turn this class into an interface, but I'm not sure about side effects (see #1034 - it is about interfaces).
These suggested changes seem to be safe enough.