### PR TITLE
Fixed two bugs regarding Semantic Module Extraction

### DIFF
--- a/tools/src/main/java/org/semanticweb/owlapi/modularity/ModuleExtractor.java
+++ b/tools/src/main/java/org/semanticweb/owlapi/modularity/ModuleExtractor.java
@@ -30,7 +30,7 @@ import org.semanticweb.owlapi.modularity.locality.SyntacticLocalityEvaluator;
 
 /**
  * Interface for classes that extract modules based on fixed axiom bases. Implementations of this
- * interface may use precomputation to optimize calculating multiple modules for the same axiom base
+ * interface may use pre-computation to optimize calculating multiple modules for the same axiom base
  * but for differing signatures.
  *
  * @author Marc Robin Nolte
@@ -38,7 +38,7 @@ import org.semanticweb.owlapi.modularity.locality.SyntacticLocalityEvaluator;
 public interface ModuleExtractor {
 
     /**
-     * Return the axioms all modules of this {@link ModuleExtractor} are computed against, including
+     * Return the axioms all modules of this ModuleExtractor are computed against, including
      * global axioms and tautologies.
      *
      * @return The axioms as specified above
@@ -47,7 +47,7 @@ public interface ModuleExtractor {
     Stream<OWLAxiom> axiomBase();
 
     /**
-     * Returns whether or not the axiom base of this {@link ModuleExtractor} contains the given
+     * Returns whether the axiom base of this ModuleExtractor contains the given
      * {@link OWLAxiom}.
      *
      * @param axiom The axiom to test
@@ -58,12 +58,12 @@ public interface ModuleExtractor {
     }
 
     /**
-     * Returns <code>true</code> if it is guaranteed that the given {@link OWLAxiom} is contained in
-     * every module calculated by the module extraction method this {@link ModuleExtractor} is based
-     * on; <code>false</code> when no such guarantee can be made (Note: This does not mean that
+     * Returns {@code true} if it is guaranteed that the given {@link OWLAxiom} is contained in
+     * every module calculated by the module extraction method this ModuleExtractor is based
+     * on; {@code false} when no such guarantee can be made (Note: This does not mean that
      * there is some module regardless of other axioms or the signature that does not contain the
-     * given axiom). This methods returning <code>true</code> implies that
-     * {@link ModuleExtractor#noModuleContains(OWLAxiom)} returns <code>false</code> for the same
+     * given axiom). This methods returning {@code true} implies that
+     * {@link ModuleExtractor#noModuleContains(OWLAxiom)} returns {@code false} for the same
      * axiom.
      *
      * @param axiom The {@link OWLAxiom} to check
@@ -75,18 +75,19 @@ public interface ModuleExtractor {
 
     /**
      * Extracts a module with respect to the given signature against the axiom base of this
-     * {@link ModuleExtractor}.
+     * ModuleExtractor.
      *
      * @param signature The signature the module should be extracted against
      * @return The axioms of the module with respect to the given signature
      */
-    default @Nonnull Stream<OWLAxiom> extract(Stream<OWLEntity> signature) {
+    @Nonnull
+    default Stream<OWLAxiom> extract(Stream<OWLEntity> signature) {
         return extract(signature, Optional.empty());
     }
 
     /**
      * Extracts a module with respect to the given signature against the subset of the axiom base
-     * this {@link ModuleExtractor}s axiom base that matches the given {@link Predicate}, if any.
+     * this ModuleExtractor's axiom base that matches the given {@link Predicate}, if any.
      *
      * @param signature The signature the module should be extracted against.
      * @param axiomFilter An {@link Optional} {@link Predicate} that filters a subset of the axiom
@@ -99,14 +100,14 @@ public interface ModuleExtractor {
      */
     @Nonnull
     Stream<OWLAxiom> extract(Stream<OWLEntity> signature,
-        Optional<Predicate<OWLAxiom>> axiomFilter);
+                             Optional<Predicate<OWLAxiom>> axiomFilter);
 
     /**
      * Extracts a module with respect to the given signature against the subset of the axiom base
-     * this {@link ModuleExtractor}s axiom base that matches the given {@link Predicate}.
+     * this ModuleExtractor's axiom base that matches the given {@link Predicate}.
      *
      * @param signature The signature the module should be extracted against.
-     * @param axiomFilter An {@link Predicate} that filters a subset of the axiom base to extract
+     * @param axiomFilter A {@link Predicate} that filters a subset of the axiom base to extract
      *        the module against. Note that ignoring some axiom may lead to other axioms not be
      *        contained in the module either. For example, consider the ontology O:= {A⊑B, B⊑C, C⊑D}
      *        and the signature {A,E}. {@link SyntacticLocalityEvaluator} with
@@ -115,7 +116,7 @@ public interface ModuleExtractor {
      * @return The axioms of the module with respect to the given signature
      */
     default @Nonnull Stream<OWLAxiom> extract(Stream<OWLEntity> signature,
-        Predicate<OWLAxiom> axiomFilter) {
+                                              Predicate<OWLAxiom> axiomFilter) {
         return extract(signature, Optional.ofNullable(axiomFilter));
     }
 
@@ -143,7 +144,7 @@ public interface ModuleExtractor {
 
     /**
      * Returns from the axiom base of this extractor exactly those that are guaranteed to be
-     * contained in every module calculated by this {@link ModuleExtractor}. These axioms may be
+     * contained in every module calculated by this ModuleExtractor. These axioms may be
      * precomputed or calculated on every call of this method.
      *
      * @return The axioms as specified above
@@ -153,29 +154,30 @@ public interface ModuleExtractor {
     }
 
     /**
-     * Returns <code>true</code> if it is guaranteed that the given {@link OWLAxiom} is not
+     * Returns {@code true} if it is guaranteed that the given {@link OWLAxiom} is not
      * contained in any module (regardless of other axioms or the signature) calculated by the
-     * module extraction method this {@link ModuleExtractor} is based on; <code>false</code> when no
+     * module extraction method this ModuleExtractor is based on; {@code false} when no
      * such guarantee can be made (Note: This does not mean that there is some module that contains
-     * the given axiom). This methods returning <code>true</code> implies that
-     * {@link ModuleExtractor#everyModuleContains(OWLAxiom)} returns <code>false</code> for the same
+     * the given axiom). This methods returning {@code true} implies that
+     * {@link ModuleExtractor#everyModuleContains(OWLAxiom)} returns {@code false} for the same
      * axiom.
      *
      * @param axiom The {@link OWLAxiom} to check
      * @return A boolean value as specified above
      */
     default boolean noModuleContains(OWLAxiom axiom) {
-        return extract(axiom.signature(), axiom::equals).count() == 0;
+        return !extract(axiom.signature(), axiom::equals).findAny().isPresent();
     }
 
     /**
      * Returns from the axiom base of this extractor exactly those that are guaranteed not to be
-     * contained in any module calculated by this {@link ModuleExtractor}. These axioms may be
+     * contained in any module calculated by this ModuleExtractor. These axioms may be
      * precomputed or calculated on every call of this method.
      *
      * @return The axioms as specified above
      */
-    default @Nonnull Stream<OWLAxiom> tautologies() {
+    @Nonnull
+    default Stream<OWLAxiom> tautologies() {
         return axiomBase().parallel().filter(this::noModuleContains);
     }
 }

--- a/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/LocalityModuleExtractor.java
+++ b/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/LocalityModuleExtractor.java
@@ -12,12 +12,7 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License. */
 package org.semanticweb.owlapi.modularity.locality;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -47,8 +42,8 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
      * @param workingSignature working signature
      * @param evaluator        evaluator to use
      */
-    private static void addNonLocal(OWLAxiom axiom, Set<OWLEntity> signature, Set<OWLAxiom> module,
-        Set<OWLEntity> workingSignature, LocalityEvaluator evaluator) {
+    private static void addNonLocal(OWLAxiom axiom, Set<OWLEntity> signature, Collection<OWLAxiom> module,
+                                    Collection<OWLEntity> workingSignature, LocalityEvaluator evaluator) {
         if (!module.contains(axiom) && !evaluator.isLocal(axiom, signature)) {
             // M ← M ∪ α
             module.add(axiom);
@@ -75,12 +70,12 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
     private @Nonnull final Map<OWLEntity, Set<OWLAxiom>> axiomsContainingEntity = new HashMap<>();
 
     /**
-     * Creates a new {@link LocalityModuleExtractor}.
+     * Creates a new LocalityModuleExtractor.
      *
      * @param localityClass The {@link LocalityClass} to use
-     * @param axiomBase     the axiom base of the new {@link LocalityModuleExtractor}
+     * @param axiomBase     the axiom base of the new LocalityModuleExtractor
      */
-    protected LocalityModuleExtractor(LocalityClass localityClass, Stream<OWLAxiom> axiomBase) {
+    LocalityModuleExtractor(LocalityClass localityClass, Stream<OWLAxiom> axiomBase) {
         this.axiomBase = axiomBase.collect(Collectors.toSet());
         this.localityClass =
             Objects.requireNonNull(localityClass, "The given locality class may not be null.");
@@ -88,7 +83,7 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
     }
 
     @Override
-    public final @Nonnull Stream<OWLAxiom> axiomBase() {
+    public @Nonnull Stream<OWLAxiom> axiomBase() {
         return axiomBase.stream();
     }
 
@@ -104,7 +99,7 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
 
     @Override
     public final Stream<OWLAxiom> extract(Stream<OWLEntity> signature,
-        Optional<Predicate<OWLAxiom>> axiomFilter) {
+                                          Optional<Predicate<OWLAxiom>> axiomFilter) {
         Set<OWLEntity> signatureSet = signature.collect(Collectors.toSet());
         if (localityClass == LocalityClass.STAR) {
             return extractStarModule(signatureSet, axiomFilter).stream();
@@ -125,8 +120,10 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
      * @param evaluator   locality evaluator
      * @return module as a set of axioms
      */
-    protected final @Nonnull Set<OWLAxiom> extractLocalityBasedModule(Set<OWLEntity> signature,
-        Optional<Predicate<OWLAxiom>> axiomFilter, LocalityEvaluator evaluator) {
+    @Nonnull
+    private Set<OWLAxiom> extractLocalityBasedModule(Set<OWLEntity> signature,
+                                                     Optional<Predicate<OWLAxiom>> axiomFilter,
+                                                     LocalityEvaluator evaluator) {
         // Sub axiom base requires to filter the axioms
         Function<OWLEntity, Stream<OWLAxiom>> axiomsOfEntity =
             entity -> axiomsContainingEntity.get(entity).stream();
@@ -157,8 +154,8 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
      * @param axiomFilter optional filter to apply to the axioms
      * @return module as a set of axioms
      */
-    protected final @Nonnull Set<OWLAxiom> extractStarModule(Set<OWLEntity> signature,
-        Optional<Predicate<OWLAxiom>> axiomFilter) {
+    @Nonnull
+    private Set<OWLAxiom> extractStarModule(Set<OWLEntity> signature, Optional<Predicate<OWLAxiom>> axiomFilter) {
         LocalityEvaluator bottom = bottomEvaluator(); // bot or empty_set
         LocalityEvaluator top = topEvaluator(); // top or delta
         // Calculating the initial module
@@ -176,16 +173,17 @@ public abstract class LocalityModuleExtractor implements ModuleExtractor {
     }
 
     /**
-     * Returns the locality class used by this {@link LocalityModuleExtractor}.
+     * Returns the locality class used by this LocalityModuleExtractor.
      *
-     * @return The locality class used by this {@link LocalityModuleExtractor}
+     * @return The locality class used by this LocalityModuleExtractor
      */
-    public @Nonnull LocalityClass getLocalityClass() {
+    @Nonnull
+    public LocalityClass getLocalityClass() {
         return localityClass;
     }
 
     /**
-     * Initializes this {@link LocalityModuleExtractor}. Precomputes the globals and fills
+     * Initializes this LocalityModuleExtractor. Precomputes the globals and fills
      * {@link LocalityModuleExtractor#axiomsContainingEntity}.
      */
     private void initialize() {

--- a/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SemanticLocalityEvaluator.java
+++ b/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SemanticLocalityEvaluator.java
@@ -121,7 +121,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          * @param axiom The {@link OWLAxiom}, which entities should be replaced
          * @return The new {@link OWLAxiom} as specified above
          */
-        public @Nonnull OWLAxiom replaceBottom(OWLAxiom axiom) {
+        @Nonnull
+        public OWLAxiom replaceBottom(OWLAxiom axiom) {
             newAxiom = null;
             axiom.accept(this);
             if (newAxiom == null) {
@@ -138,7 +139,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          * @param classExpression The {@link OWLClassExpression}, which entities should be replaced
          * @return The new {@link OWLClassExpression} as specified above
          */
-        public @Nonnull OWLClassExpression replaceBottom(OWLClassExpression classExpression) {
+        @Nonnull
+        public OWLClassExpression replaceBottom(OWLClassExpression classExpression) {
             newClassExpression = null;
             classExpression.accept(this);
             if (newClassExpression == null) {
@@ -156,7 +158,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          *                         replaced
          * @return A {@link Stream} as specified above
          */
-        public @Nonnull Stream<OWLClassExpression> replaceBottom(
+        @Nonnull
+        public Stream<OWLClassExpression> replaceBottom(
             Stream<? extends OWLClassExpression> classExpressions) {
             return classExpressions.map(this::replaceBottom);
         }
@@ -359,7 +362,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          * @param axiom The {@link OWLAxiom}, which entities should be replaced
          * @return The new {@link OWLAxiom} as specified above
          */
-        public @Nonnull OWLAxiom replaceTop(OWLAxiom axiom) {
+        @Nonnull
+        public OWLAxiom replaceTop(OWLAxiom axiom) {
             newAxiom = null;
             axiom.accept(this);
             if (newAxiom == null) {
@@ -376,7 +380,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          * @param classExpression The {@link OWLClassExpression}, which entities should be replaced
          * @return The new {@link OWLClassExpression} as specified above
          */
-        public @Nonnull OWLClassExpression replaceTop(OWLClassExpression classExpression) {
+        @Nonnull
+        public OWLClassExpression replaceTop(OWLClassExpression classExpression) {
             newClassExpression = null;
             classExpression.accept(this);
             if (newClassExpression == null) {
@@ -394,7 +399,8 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
          *                         replaced
          * @return A {@link Stream} as specified above
          */
-        public @Nonnull Stream<OWLClassExpression> replaceTop(
+        @Nonnull
+        public Stream<OWLClassExpression> replaceTop(
             Stream<? extends OWLClassExpression> classExpressions) {
             return classExpressions.map(this::replaceTop);
         }
@@ -556,12 +562,14 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
     /**
      * The used {@link OWLDataFactory}.
      */
-    protected final @Nonnull OWLDataFactory dataFactory;
+    @Nonnull
+    protected final OWLDataFactory dataFactory;
 
     /**
      * The {@link OWLReasoner} to check if axioms are tautologies.
      */
-    private final @Nonnull OWLReasoner reasoner;
+    @Nonnull
+    private final OWLReasoner reasoner;
 
     /**
      * The {@link LocalityClass} to use.
@@ -569,7 +577,7 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
     private final LocalityClass localityClass;
 
     /**
-     * Instantiates a new {@link SemanticLocalityEvaluator}
+     * Instantiates a new SemanticLocalityEvaluator.
      *
      * @param localityClass   The {@link LocalityClass} to use. Must be one of BOTTOM or TOP
      * @param ontologyManager The {@link OWLOntologyManager} to create a reasoner with
@@ -580,7 +588,7 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
 
         this.localityClass =
             Objects.requireNonNull(localityClass, "The given  locality class may not be null.");
-        if (localityClass != LocalityClass.BOTTOM || localityClass != LocalityClass.TOP) {
+        if (localityClass != LocalityClass.BOTTOM && localityClass != LocalityClass.TOP) {
             throw new IllegalArgumentException(
                 "The given locality class must be one of BOTTOM or TOP");
         }
@@ -596,6 +604,25 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
         }
     }
 
+    /**
+     * Instantiates a new SemanticLocalityEvaluator
+     *
+     * @param localityClass   The {@link LocalityClass} to use. Must be one of BOTTOM or TOP
+     * @param reasoner        An {@link OWLReasoner} over an empty ontology to check for tautologies
+     */
+    public SemanticLocalityEvaluator(LocalityClass localityClass,
+                                     OWLReasoner reasoner) {
+
+        this.localityClass =
+                Objects.requireNonNull(localityClass, "The given  locality class may not be null.");
+        if (localityClass != LocalityClass.BOTTOM && localityClass != LocalityClass.TOP) {
+            throw new IllegalArgumentException(
+                    "The given locality class must be one of BOTTOM or TOP");
+        }
+        dataFactory = reasoner.getRootOntology().getOWLOntologyManager().getOWLDataFactory();
+        this.reasoner = reasoner;
+    }
+
     @Override
     public boolean isLocal(OWLAxiom axiom, Collection<OWLEntity> signature) {
         return !axiom.isLogicalAxiom() || reasoner.isEntailed(localityClass == LocalityClass.BOTTOM
@@ -603,6 +630,15 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
                 .replaceBottom(Objects.requireNonNull(axiom, "The given axiom may not be null"))
             : new TopReplacer(Objects.requireNonNull(signature, "signature cannot be null"))
                 .replaceTop(Objects.requireNonNull(axiom, "The given axiom may not be null")));
+    }
+
+    /**
+     * Disposes the reasoner that is used to check whether axioms are tautologies via calling {@link OWLReasoner#dispose()}.
+     * Must be called after this SemanticLocalityModuleExtractor is no longer used
+     * to free resources that are allocated by the reasoner.
+     */
+    public void dispose() {
+        reasoner.dispose();
     }
 
 }

--- a/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SemanticLocalityEvaluator.java
+++ b/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SemanticLocalityEvaluator.java
@@ -604,25 +604,6 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
         }
     }
 
-    /**
-     * Instantiates a new SemanticLocalityEvaluator
-     *
-     * @param localityClass   The {@link LocalityClass} to use. Must be one of BOTTOM or TOP
-     * @param reasoner        An {@link OWLReasoner} over an empty ontology to check for tautologies
-     */
-    public SemanticLocalityEvaluator(LocalityClass localityClass,
-                                     OWLReasoner reasoner) {
-
-        this.localityClass =
-                Objects.requireNonNull(localityClass, "The given  locality class may not be null.");
-        if (localityClass != LocalityClass.BOTTOM && localityClass != LocalityClass.TOP) {
-            throw new IllegalArgumentException(
-                    "The given locality class must be one of BOTTOM or TOP");
-        }
-        dataFactory = reasoner.getRootOntology().getOWLOntologyManager().getOWLDataFactory();
-        this.reasoner = reasoner;
-    }
-
     @Override
     public boolean isLocal(OWLAxiom axiom, Collection<OWLEntity> signature) {
         return !axiom.isLogicalAxiom() || reasoner.isEntailed(localityClass == LocalityClass.BOTTOM
@@ -633,11 +614,12 @@ public class SemanticLocalityEvaluator implements LocalityEvaluator {
     }
 
     /**
-     * Disposes the reasoner that is used to check whether axioms are tautologies via calling {@link OWLReasoner#dispose()}.
-     * Must be called after this SemanticLocalityModuleExtractor is no longer used
-     * to free resources that are allocated by the reasoner.
+     * Disposes the reasoner and the empty ontology that is used to check whether axioms are tautologies via calling {@link OWLReasoner#dispose()}.
+     * Must be called after this SemanticLocalityEvaluator is no longer used
+     * to free resources that are allocated by the reasoner and the ontology.
      */
     public void dispose() {
+        reasoner.getRootOntology().getOWLOntologyManager().removeOntology(reasoner.getRootOntology());
         reasoner.dispose();
     }
 

--- a/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SyntacticLocalityEvaluator.java
+++ b/tools/src/main/java/org/semanticweb/owlapi/modularity/locality/SyntacticLocalityEvaluator.java
@@ -37,7 +37,6 @@ import java.util.Objects;
 
 import javax.annotation.Nonnull;
 
-import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.OWLAsymmetricObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLAxiomVisitor;


### PR DESCRIPTION
1. It was impossible to instantiate a `SemanticLocalityEvaluator` because `localityClass != LocalityClass.BOTTOM || localityClass != LocalityClass.TOP` always returns true. Yes, I'm dumb.

2. Possible memory leak was adressed: `SemanticLocalityEvaluator` creates a reasoner over a new empty ontology to check for tautologies but did not dispose either because it did not knew when its lifecycle was over. For that, I added a method "dispose" both in `SemanticLocalityEvaluator` and in `SemanticLocalityModuleExtractor` that can be called externally. As a side note - is there a better way to create an empty ontology other than with an `OWLOntologyManager` that has to be notified when the ontology can be garbage collected (via `remove()`)?