### PR TITLE
Update OWLOntologyID.java

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/model/OWLOntologyID.java
+++ b/api/src/main/java/org/semanticweb/owlapi/model/OWLOntologyID.java
@@ -178,7 +178,7 @@ public class OWLOntologyID implements Comparable<OWLOntologyID>, Serializable, I
      * @return true if the input id has the same ontology iri
      */
     public boolean match(OWLOntologyID id) {
-        return ontologyIRI.equals(id.getOntologyIRI());
+        return this.equals(id);
     }
 
     /**


### PR DESCRIPTION
I think the `OWLOnotlogyID` should match checking the ontology version iri when it is present (i.e. using the already implemented `equals`). 

I've had some problems loading into the `OWLOntologyManager` multiple "same ontology iri" (e.g. `http://example.com/` ontologies with increasing versions (e.g. `http://example.com/1.0`, `http://example.com/1.1`).

More precisely when the `contains(OWLOntologyID)` is called:
https://github.com/owlcs/owlapi/blob/3bce72460c87fd20e1ef2479273f375a7cdaae21/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLOntologyManagerImpl.java#L366