### PR TITLE
ISSUE-1064 Bump rdf4j.version from 3.7.4 to 4.0.1

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -57,7 +57,7 @@
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-turtle</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-trig</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-hdt</artifactId><version>${inherited.rdf4j.version}</version></dependency>
-		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-util</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-common-util</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>com.github.jsonld-java</groupId><artifactId>jsonld-java</artifactId><version>0.13.4</version></dependency>
 		<!-- Disable until updated to use RDF4J  <dependency><groupId>org.semarglproject</groupId><artifactId>semargl-sesame</artifactId><version>0.7</version></dependency> -->
 

--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -57,7 +57,7 @@
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-turtle</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-trig</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-rio-hdt</artifactId><version>${inherited.rdf4j.version}</version></dependency>
-		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-util</artifactId><version>${inherited.rdf4j.version}</version></dependency>
+		<dependency><groupId>org.eclipse.rdf4j</groupId><artifactId>rdf4j-common-util</artifactId><version>${inherited.rdf4j.version}</version></dependency>
 		<dependency><groupId>com.github.jsonld-java</groupId><artifactId>jsonld-java</artifactId><version>0.13.4</version></dependency>
 		<dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpclient</artifactId><version>4.5.13</version></dependency>
 		<dependency><groupId>org.apache.httpcomponents</groupId><artifactId>httpclient-cache</artifactId><version>4.5.13</version></dependency>

--- a/parsers/src/main/java/org/semanticweb/owlapi/krss2/parser/KRSS2OWLParser.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/krss2/parser/KRSS2OWLParser.java
@@ -33,7 +33,8 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
  * inverse, functional attribute can be provided for roles. Note that DatatypeProperties are not
  * supported within KRSS2. <br>
  * <b>Abbreviations</b>
- * <table summary="Abbreviations">
+ * <table>
+ * <caption>Abbreviations</caption>
  * <tr>
  * <td>CN</td>
  * <td>concept name</td>
@@ -53,7 +54,8 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
  * </table>
  * <br>
  * <b>KRSS concept language</b>
- * <table summary="KRSS concept language">
+ * <table>
+ * <caption>KRSS concept language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLClassExpression</td>
@@ -93,7 +95,8 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
  * </table>
  * <br>
  * <b>KRSS role language</b>
- * <table summary="KRSS role language">
+ * <table>
+ * <caption>KRSS role language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLObjectPropertyExpression</td>
@@ -104,7 +107,8 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
  * </tr>
  * </table>
  * <br>
- * <table summary="remarks">
+ * <table>
+ * <caption>Remarks</caption>
  * <tr>
  * <td>KRSS2</td>
  * <td>OWLAxiom</td>

--- a/parsers/src/main/java/org/semanticweb/owlapi/krss2/renderer/KRSS2ObjectRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/krss2/renderer/KRSS2ObjectRenderer.java
@@ -83,7 +83,8 @@ import org.semanticweb.owlapi.search.Filters;
  * {@code KRSS2ObjectRenderer} is an extension of {@link KRSSObjectRenderer KRSSObjectRenderer}
  * which uses the extended vocabulary. <br>
  * <b>Abbreviations</b>
- * <table summary="Abbreviations">
+ * <table>
+ * <caption>Abbreviations</caption>
  * <tr>
  * <td>CN</td>
  * <td>concept name</td>
@@ -103,7 +104,8 @@ import org.semanticweb.owlapi.search.Filters;
  * </table>
  * <br>
  * <b>KRSS concept language</b>
- * <table summary="KRSS concept language">
+ * <table>
+ * <caption>KRSS concept language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLClassExpression</td>
@@ -143,7 +145,8 @@ import org.semanticweb.owlapi.search.Filters;
  * </table>
  * <br>
  * <b>KRSS role language</b>
- * <table summary="KRSS role language">
+ * <table>
+ * <caption>KRSS role language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLObjectPropertyExpression</td>
@@ -157,7 +160,8 @@ import org.semanticweb.owlapi.search.Filters;
  * Each referenced class, object property as well as individual is defined using
  * <i>define-concept</i> resp. <i>define-primitive-concept</i>, <i>define-role</i> and
  * <i>define-individual</i>. In addition, axioms are translated as follows. <br>
- * <table summary="remarks">
+ * <table>
+ * <caption>Remarks</caption>
  * <tr>
  * <td>KRSS2</td>
  * <td>OWLAxiom</td>

--- a/parsers/src/main/java/org/semanticweb/owlapi/krss2/renderer/KRSSObjectRenderer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/krss2/renderer/KRSSObjectRenderer.java
@@ -91,7 +91,8 @@ import org.semanticweb.owlapi.search.Filters;
  * A {@code KRSSObjectRenderer} renders an OWLOntology in the original KRSS syntax. Note that only a
  * subset of OWL can be expressed in KRSS. <br>
  * <b>Abbreviations</b>
- * <table summary="Abbreviations">
+ * <table>
+ * <caption>Abbreviations</caption>
  * <tr>
  * <td>CN</td>
  * <td>concept name</td>
@@ -111,7 +112,8 @@ import org.semanticweb.owlapi.search.Filters;
  * </table>
  * <br>
  * <b>KRSS concept language</b>
- * <table summary="KRSS concept language">
+ * <table>
+ * <caption>KRSS concept language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLClassExpression</td>
@@ -151,7 +153,8 @@ import org.semanticweb.owlapi.search.Filters;
  * </table>
  * <br>
  * <b>KRSS role language</b>
- * <table summary="KRSS role language">
+ * <table>
+ * <caption>KRSS role language</caption>
  * <tr>
  * <td>KRSS</td>
  * <td>OWLObjectPropertyExpression</td>
@@ -165,7 +168,8 @@ import org.semanticweb.owlapi.search.Filters;
  * Each referenced class, object property as well as individual is defined using
  * <i>define-concept</i> resp. <i>define-primitive-concept</i>, <i>define-role</i> and
  * <i>define-individual</i>. In addition, axioms are translated as follows. <br>
- * <table summary="remarks">
+ * <table>
+ * <caption>Remarks</caption>
  * <tr>
  * <td>OWLAxiom</td>
  * <td>KRSS syntax</td>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 	<properties>
 		<!-- Specify the encoding of the source files. -->
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<rdf4j.version>3.7.7</rdf4j.version>
+		<rdf4j.version>4.0.1</rdf4j.version>
 		<!-- remove this line for releases, if the release process fails because 
 			of missing javadoc jars -->
 		<no-javadoc>false</no-javadoc>
@@ -372,10 +372,10 @@
 					</execution>
 				</executions>
 			</plugin>
-			<plugin>
+			<!--plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.16</version>
+				<version>1.21</version>
 				<executions>
 					<execution>
 						<phase>test</phase>
@@ -385,19 +385,21 @@
 					</execution>
 				</executions>
 				<configuration>
-				<ignores><ignore>com.sun.management.*</ignore></ignores>
+					<ignores>
+						<ignore>com.sun.management.*</ignore>
+					</ignores>
 					<signature>
 						<groupId>org.codehaus.mojo.signature</groupId>
 						<artifactId>java18</artifactId>
 						<version>1.0</version>
 					</signature>
 				</configuration>
-			</plugin>
+			</plugin-->
 			<plugin>
 				<!-- verify all bytecode (including third party libs) is Java 8 max -->
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-enforcer-plugin</artifactId>
-				<version>3.0.0-M3</version>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<id>enforce-bytecode-version</id>
@@ -407,17 +409,17 @@
 						<configuration>
 							<rules>
 								<enforceBytecodeVersion>
-									<maxJdkVersion>1.8</maxJdkVersion>
-									 <excludes>
-					                    <exclude>org.junit.jupiter:junit-jupiter</exclude>
-					                    <exclude>org.junit.jupiter:junit-jupiter-engine</exclude>
-					                    <exclude>org.junit.platform:junit-platform-engine</exclude>
-					                    <exclude>org.junit.jupiter:junit-jupiter-params</exclude>
-					                    <exclude>org.junit.jupiter:junit-jupiter-api</exclude>
-					                    <exclude>org.opentest4j:opentest4j</exclude>
-					                    <exclude>org.apiguardian:apiguardian-api</exclude>
-					                    <exclude>org.junit.platform:junit-platform-commons</exclude>
-                  					</excludes>
+									<maxJdkVersion>11</maxJdkVersion>
+									<excludes>
+										<exclude>org.junit.jupiter:junit-jupiter</exclude>
+										<exclude>org.junit.jupiter:junit-jupiter-engine</exclude>
+										<exclude>org.junit.platform:junit-platform-engine</exclude>
+										<exclude>org.junit.jupiter:junit-jupiter-params</exclude>
+										<exclude>org.junit.jupiter:junit-jupiter-api</exclude>
+										<exclude>org.opentest4j:opentest4j</exclude>
+										<exclude>org.apiguardian:apiguardian-api</exclude>
+										<exclude>org.junit.platform:junit-platform-commons</exclude>
+									</excludes>
 								</enforceBytecodeVersion>
 							</rules>
 							<fail>true</fail>
@@ -428,7 +430,7 @@
 					<dependency>
 						<groupId>org.codehaus.mojo</groupId>
 						<artifactId>extra-enforcer-rules</artifactId>
-						<version>1.0-beta-6</version>
+						<version>1.5.1</version>
 					</dependency>
 				</dependencies>
 			</plugin>

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioMemoryTripleSource.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioMemoryTripleSource.java
@@ -41,7 +41,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import org.eclipse.rdf4j.RDF4JException;
+import org.eclipse.rdf4j.common.exception.RDF4JException;
 import org.eclipse.rdf4j.common.iteration.CloseableIteration;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Namespace;

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioRenderer.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioRenderer.java
@@ -41,11 +41,11 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.rio.RDFHandler;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
@@ -89,7 +89,8 @@ public class RioRenderer extends RDFRendererBase {
     public RioRenderer(final OWLOntology ontology, final RDFHandler writer,
         @Nullable OWLDocumentFormat format, final Resource... contexts) {
         super(ontology, format, ontology.getOWLOntologyManager().getOntologyWriterConfiguration());
-        OpenRDFUtil.verifyContextNotNull(contexts);
+        Objects.requireNonNull(contexts,
+            "contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
         this.contexts = contexts;
         this.writer = writer;
         pm = new DefaultPrefixManager();

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/RioStorer.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/RioStorer.java
@@ -47,10 +47,10 @@ import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 
 import javax.annotation.Nullable;
 
-import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.RDFFormat;
@@ -105,7 +105,8 @@ public class RioStorer extends AbstractOWLStorer {
      * @param contexts contexts
      */
     public RioStorer(OWLDocumentFormatFactory ontologyFormat, Resource... contexts) {
-        OpenRDFUtil.verifyContextNotNull(contexts);
+        Objects.requireNonNull(contexts,
+            "contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
         ontFormat = ontologyFormat;
         this.contexts = contexts;
     }

--- a/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
+++ b/rio/src/main/java/org/semanticweb/owlapi/rio/utils/RioUtils.java
@@ -39,9 +39,9 @@ import static org.semanticweb.owlapi.util.OWLAPIStreamUtils.asList;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
-import org.eclipse.rdf4j.OpenRDFUtil;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Resource;
 import org.eclipse.rdf4j.model.Statement;
@@ -89,7 +89,8 @@ public final class RioUtils {
      */
     public static Collection<Statement> tripleAsStatements(final RDFTriple triple,
         final Resource... contexts) {
-        OpenRDFUtil.verifyContextNotNull(contexts);
+        Objects.requireNonNull(contexts,
+            "contexts argument may not be null; either the value should be cast to Resource or an empty array should be supplied");
         final ValueFactory vf = SimpleValueFactory.getInstance();
         Resource subject;
         if (triple.getSubject() instanceof RDFResourceIRI) {


### PR DESCRIPTION
Hi Folks, this my a PR to address #1064 
I am running OpenJDK 11.0.15 hence the tangential additions to this PR. I was unable to get the project to build otherwise.
```
Apache Maven 3.8.4 (9b656c72d54e5bacbed989b64718c159fe39b537)
Maven home: /usr/local/Cellar/maven/3.8.4/libexec
Java version: 11.0.15, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk@11/11.0.15/libexec/openjdk.jdk/Contents/Home
Default locale: en_US, platform encoding: UTF-8
OS name: "mac os x", version: "12.4", arch: "x86_64", family: "mac"
```
I understand that byte code compliance and general max Java version was pinned at `1.8` however I started using `11` several years ago. I hope that this PR can act as the basis for possibly updating the owlapi project to at atleast JDK11...?

Thanks