### PR TITLE
fix xsd name of XSDVocabulary.G_MONTH_DAY

### DIFF
--- a/api/src/main/java/org/semanticweb/owlapi/vocab/XSDVocabulary.java
+++ b/api/src/main/java/org/semanticweb/owlapi/vocab/XSDVocabulary.java
@@ -69,7 +69,7 @@ public enum XSDVocabulary implements HasShortForm, HasIRI, HasPrefixedName {
     /** DATE. */                 DATE            ("date"),
     /** G_YEAR_MONTH. */         G_YEAR_MONTH    ("gYearMonth"),
     /** G_YEAR. */               G_YEAR          ("gYear"),
-    /** G_MONTH_DAY. */          G_MONTH_DAY     ("gMonthYear"),
+    /** G_MONTH_DAY. */          G_MONTH_DAY     ("gMonthDay"),
     /** G_DAY. */                G_DAY           ("gDay"),
     /** G_MONTH. */              G_MONTH         ("gMonth"),
     /** UNSIGNED_SHORT. */       UNSIGNED_SHORT  ("unsignedShort"),


### PR DESCRIPTION
The name of ```XSDVocabulary.G_MONTH_DAY``` enum item is fixed, reference page is:  https://www.w3.org/TR/2001/REC-xmlschema-2-20010502/#gMonthDay