### PR TITLE
OBO parser: Treat value of `replaced_by` tag as an IRI

### DIFF
--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
@@ -606,7 +606,12 @@ public class OWLAPIObo2Owl {
                 headerFrame.getClauses(t).forEach(c -> addOntologyAnnotation(fac.getRDFSComment(),
                     trLiteral(c.getValue()), trAnnotations(c)));
             } else if (tag == OboFormatTag.TAG_IDSPACE) {
-                // do not translate, as they are just directives
+                for (Clause clause : headerFrame.getClauses(t)) {
+                    Object[] values = clause.getValues().toArray();
+                    String prefix = values[0].toString() + '_';
+                    String baseurl = values[1].toString();
+                    idSpaceMap.put(prefix, baseurl);
+                }
             } else if (tag == OboFormatTag.TAG_OWL_AXIOMS) {
                 // in theory, there should only be one tag
                 // but we can silently collapse multiple tags

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
@@ -1195,7 +1195,8 @@ public class OWLAPIObo2Owl {
             }
             ax = fac.getOWLAnnotationAssertionAxiom(trTagToAnnotationProp(tag), sub,
                 trLiteral(clause.getValue()), annotations);
-        } else if (tagConstant == OboFormatTag.TAG_REPLACED_BY) {
+        } else if (tagConstant == OboFormatTag.TAG_REPLACED_BY
+                || tagConstant == OboFormatTag.TAG_CONSIDER) {
             String curie = (String) clause.getValue();
             IRI iri = oboIdToIRI(curie);
             ax = fac.getOWLAnnotationAssertionAxiom(trTagToAnnotationProp(tag), sub,

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
@@ -1190,6 +1190,11 @@ public class OWLAPIObo2Owl {
             }
             ax = fac.getOWLAnnotationAssertionAxiom(trTagToAnnotationProp(tag), sub,
                 trLiteral(clause.getValue()), annotations);
+        } else if (tagConstant == OboFormatTag.TAG_REPLACED_BY) {
+            String curie = (String) clause.getValue();
+            IRI iri = oboIdToIRI(curie);
+            ax = fac.getOWLAnnotationAssertionAxiom(trTagToAnnotationProp(tag), sub,
+                 iri, annotations);
         } else {
             // generic
             ax = fac.getOWLAnnotationAssertionAxiom(trTagToAnnotationProp(tag), sub,


### PR DESCRIPTION
This PR is a proof-of-concept fix for the issue mentioned in https://github.com/INCATools/ontology-development-kit/issues/642, i.e. the fact that the value of a `replaced_by` tag in a OBO file is translated into a literal string, instead of an IRI as expected.

The fix has two parts:
* The first part is to change the way `replaced_by` clauses are translated by converting the value into an IRI, instead of leaving it as a string. This covers both the case where the value is already a full URL and the case where the value is a OBO CURIE, thanks to the `loadIdToIRI` method. This does not, however, cover the case of non-OBO CURIEs.
* The second part makes the parser honour the `idspace` tags optionally found in the header frame, by feeding the specified prefix and corresponding base URL into the `idSpaceMap` hash map, which is already used by the `loadIdToIRI` method when expanding CURIEs. This covers the case of non-OBO CURIEs, by making sure they are expanded to the correct IRI instead of the default `http://purl.obolibrary.org/obo/`.