### PR TITLE
Accept JDK 1.9 bytecode from the Jackson dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -417,6 +417,9 @@
 					                    <exclude>org.opentest4j:opentest4j</exclude>
 					                    <exclude>org.apiguardian:apiguardian-api</exclude>
 					                    <exclude>org.junit.platform:junit-platform-commons</exclude>
+							    <exclude>com.fasterxml.jackson.core:jackson-databind</exclude>
+							    <exclude>com.fasterxml.jackson.core:jackson-core</exclude>
+							    <exclude>com.fasterxml.jackson.core:jackson-annotations</exclude>
                   					</excludes>
 								</enforceBytecodeVersion>
 							</rules>


### PR DESCRIPTION
The dependencies from the Jackson project (com.fasterxml.jackson.core:*) contain, in their recent 2.12.6 version, bytecode targeting JDK 1.9.

This cause the build of the OWLAPI :: RDF4J Rio module to fail because we enforce that all our bytecode (including from dependencies) is targeting JDK 1.8 max.

This PR adds the Jackson modules to the list of dependencies excluded from the bytecode check.