### PR TITLE
OBO serializer incorrectly quoting IRI property values

### DIFF
--- a/contract/src/test/resources/obo/writer_round_trip.obo
+++ b/contract/src/test/resources/obo/writer_round_trip.obo
@@ -41,7 +41,6 @@ comment: The embryo proper is the entire embryo exclusive of the suspensor.
 synonym: "embri&#243foro (Spanish, exact)" EXACT Spanish [POC:Maria_Alejandra_Gandolfo]
 synonym: "胚本体 (Japanese, exact)" EXACT Japanese [NIG:Yukiko_Yamazaki]
 xref: PO_GIT:246
-customTag: custom value
 property_value: dc-source http://purl.obolibrary.org/obo/aao.owl
 property_value: dc-source "ISBN:0030229073 Invertebrate Zoology, Barnes" xsd:string
 property_value: depicted_by http://upload.wikimedia.org/wikipedia/commons/4/41/Parts_of_feather_modified.jpg

--- a/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
+++ b/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
@@ -279,36 +279,36 @@ public class OBOFormatWriter {
      * @param writer the writer
      * @throws IOException Signals that an I/O exception has occurred.
      */
-	public static void writePropertyValue(Clause clause, Writer writer) throws IOException {
-		Collection<?> cols = clause.getValues();
-		if (cols.size() < 2) {
-			LOG.error("The {} has incorrect number of values: {}", OboFormatTag.TAG_PROPERTY_VALUE.getTag(), clause);
-			return;
-		}
-		Object v = clause.getValue();
-		Object v2 = clause.getValue2();
+    public static void writePropertyValue(Clause clause, Writer writer) throws IOException {
+        Collection<?> cols = clause.getValues();
+        if (cols.size() < 2) {
+            LOG.error("The {} has incorrect number of values: {}", OboFormatTag.TAG_PROPERTY_VALUE.getTag(), clause);
+            return;
+        }
+        Object v = clause.getValue();
+        Object v2 = clause.getValue2();
 
-		StringBuilder sb = new StringBuilder();
-		sb.append(clause.getTag());
-		sb.append(": ");
-		sb.append(escapeOboString(v.toString(), EscapeMode.SIMPLE));
-		sb.append(' ');
-		if (cols.size() == 2) {
-			sb.append(escapeOboString(v2.toString(), EscapeMode.SIMPLE));
-		} else if (cols.size() == 3) {
-			Iterator<Object> it = clause.getValues().iterator();
-			it.next();
-			it.next();
-			String v3String = (String) it.next();
-			sb.append('"');
-			sb.append(escapeOboString(v2.toString(), EscapeMode.QUOTES));
-			sb.append('"');
-			sb.append(' ');
-			sb.append(escapeOboString(v3String, EscapeMode.SIMPLE));
-		}
-		appendQualifiers(sb, clause);
-		writeLine(sb, writer);
-	}
+        StringBuilder sb = new StringBuilder();
+        sb.append(clause.getTag());
+        sb.append(": ");
+        sb.append(escapeOboString(v.toString(), EscapeMode.SIMPLE));
+        sb.append(' ');
+        if (cols.size() == 2) {
+            sb.append(escapeOboString(v2.toString(), EscapeMode.SIMPLE));
+        } else if (cols.size() == 3) {
+            Iterator<Object> it = clause.getValues().iterator();
+            it.next();
+            it.next();
+            String v3String = (String) it.next();
+            sb.append('"');
+            sb.append(escapeOboString(v2.toString(), EscapeMode.QUOTES));
+            sb.append('"');
+            sb.append(' ');
+            sb.append(escapeOboString(v3String, EscapeMode.SIMPLE));
+        }
+        appendQualifiers(sb, clause);
+        writeLine(sb, writer);
+    }
 
     /**
      * Write synonym.

--- a/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
+++ b/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
@@ -286,29 +286,27 @@ public class OBOFormatWriter {
                 OboFormatTag.TAG_PROPERTY_VALUE.getTag(), clause);
             return;
         }
+        Object v = clause.getValue();
+        Object v2 = clause.getValue2();
+        
         StringBuilder sb = new StringBuilder();
         sb.append(clause.getTag());
         sb.append(": ");
-        Iterator<?> it = cols.iterator();
-        // write property
-        // TODO replace toString() method
-        String property = it.next().toString();
-        sb.append(escapeOboString(property, EscapeMode.SIMPLE));
-        // write value and optional type
-        if (it.hasNext()) {
-            // value
-            sb.append(' ');
-            String val = it.next().toString(); // TODO replace toString() method
-            sb.append('"');
-            sb.append(escapeOboString(val, EscapeMode.QUOTES));
-            sb.append('"');
-        }
-        while (it.hasNext()) {
-            // optional type; there should be only one value left in the iterator
-            sb.append(' ');
-            String val = it.next().toString(); // TODO replace toString() method
-            sb.append(escapeOboString(val, EscapeMode.SIMPLE));
-        }
+		sb.append(escapeOboString(v.toString(), EscapeMode.SIMPLE));
+		sb.append(' ');
+		if (cols.size() == 2) {
+			sb.append(escapeOboString(v2.toString(), EscapeMode.SIMPLE));
+		} else if (cols.size() == 3) {
+            Iterator<Object> it = clause.getValues().iterator();
+            it.next();
+            it.next();
+            String v3String = (String) it.next();
+			sb.append('"');
+			sb.append(escapeOboString(v2.toString(), EscapeMode.QUOTES));
+			sb.append('"');
+			sb.append(' ');
+			sb.append(escapeOboString(v3String, EscapeMode.SIMPLE));
+		}
         appendQualifiers(sb, clause);
         writeLine(sb, writer);
     }

--- a/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
+++ b/oboformat/src/main/java/org/obolibrary/oboformat/writer/OBOFormatWriter.java
@@ -279,37 +279,36 @@ public class OBOFormatWriter {
      * @param writer the writer
      * @throws IOException Signals that an I/O exception has occurred.
      */
-    public static void writePropertyValue(Clause clause, Writer writer) throws IOException {
-        Collection<?> cols = clause.getValues();
-        if (cols.size() < 2) {
-            LOG.error("The {} has incorrect number of values: {}",
-                OboFormatTag.TAG_PROPERTY_VALUE.getTag(), clause);
-            return;
-        }
-        Object v = clause.getValue();
-        Object v2 = clause.getValue2();
-        
-        StringBuilder sb = new StringBuilder();
-        sb.append(clause.getTag());
-        sb.append(": ");
+	public static void writePropertyValue(Clause clause, Writer writer) throws IOException {
+		Collection<?> cols = clause.getValues();
+		if (cols.size() < 2) {
+			LOG.error("The {} has incorrect number of values: {}", OboFormatTag.TAG_PROPERTY_VALUE.getTag(), clause);
+			return;
+		}
+		Object v = clause.getValue();
+		Object v2 = clause.getValue2();
+
+		StringBuilder sb = new StringBuilder();
+		sb.append(clause.getTag());
+		sb.append(": ");
 		sb.append(escapeOboString(v.toString(), EscapeMode.SIMPLE));
 		sb.append(' ');
 		if (cols.size() == 2) {
 			sb.append(escapeOboString(v2.toString(), EscapeMode.SIMPLE));
 		} else if (cols.size() == 3) {
-            Iterator<Object> it = clause.getValues().iterator();
-            it.next();
-            it.next();
-            String v3String = (String) it.next();
+			Iterator<Object> it = clause.getValues().iterator();
+			it.next();
+			it.next();
+			String v3String = (String) it.next();
 			sb.append('"');
 			sb.append(escapeOboString(v2.toString(), EscapeMode.QUOTES));
 			sb.append('"');
 			sb.append(' ');
 			sb.append(escapeOboString(v3String, EscapeMode.SIMPLE));
 		}
-        appendQualifiers(sb, clause);
-        writeLine(sb, writer);
-    }
+		appendQualifiers(sb, clause);
+		writeLine(sb, writer);
+	}
 
     /**
      * Write synonym.

--- a/oboformat/src/test/java/org/semanticweb/owlapi/oboformat/writer/OBOFormatWriterTest.java
+++ b/oboformat/src/test/java/org/semanticweb/owlapi/oboformat/writer/OBOFormatWriterTest.java
@@ -1,0 +1,46 @@
+package org.semanticweb.owlapi.oboformat.writer;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.obolibrary.oboformat.model.OBODoc;
+import org.obolibrary.oboformat.parser.OBOFormatParser;
+import org.obolibrary.oboformat.writer.OBOFormatWriter;
+
+public class OBOFormatWriterTest {
+
+	private static final String FILE_TEST_NAME1 = "example1.obo";
+
+	@Test
+	public void testOBOFormatRoundTrip() throws IOException {
+		File oboFile = new File(this.getClass().getClassLoader().getResource(FILE_TEST_NAME1).getFile());
+
+		assertNotNull(oboFile);
+		OBOFormatParser parser = new OBOFormatParser();
+		OBODoc oboDoc = parser.parse(oboFile);
+		assertNotNull(oboDoc);
+
+		OBOFormatWriter writer = new OBOFormatWriter();
+		StringWriter stringWriter = new StringWriter();
+		writer.write(oboDoc, stringWriter);
+		
+		final List<String> outputLines = Arrays.asList(stringWriter.toString().split("\n"));
+		try (Stream<String> stream = Files.lines(oboFile.toPath(), StandardCharsets.UTF_8)) {
+			stream.forEach(s -> assertTrue(outputLines.contains(s),
+					String.format("'%s' doesn't exist in the output file.", s)));
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+	}
+
+}


### PR DESCRIPTION
Fix for the issue #1083 

In relation with the OBO Specification of the `property_value`, this fix serializes IRI values without the double quotes.

>property_value
    This tag binds a property to a value in this instance. The value of this tag is a relationship type id, a space, and a value specifier. The value specifier may have one of two forms; in the first form, it is just the id of some other instance, relationship type or term. In the second form, the value is given by a quoted string, a space, and datatype identifier. See 
[IDs](https://owlcollab.github.io/oboformat/doc/GO.format.obo-1_4.html#S.1.6) for more information on legal datatype identifiers.


In order to distinguish IRI values from the quoted string values, heuristic approach applied in the [OWLAPIObo2Owl](https://github.com/owlcs/owlapi/blob/version5/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java#L1142) is replicated:
```
If Clause has 2 values then it is `relationship type id` + `IRI`. 
If Clause has 3 values then it is `relationship type id` + `value in quoted strings` + `datatype identifier`
```
