### PR TITLE
OWL to OBO conversion error log

### DIFF
--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OwlStringTools.java
@@ -19,8 +19,10 @@ import org.semanticweb.owlapi.io.StringDocumentSource;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLOntology;
+import org.semanticweb.owlapi.model.OWLOntologyBuilder;
 import org.semanticweb.owlapi.model.OWLOntologyCreationException;
 import org.semanticweb.owlapi.model.OWLOntologyFactory;
+import org.semanticweb.owlapi.model.OWLOntologyID;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.UnloadableImportException;
 import org.semanticweb.owlapi.utilities.Injector;
@@ -88,6 +90,12 @@ public class OwlStringTools {
     private static Injector injector() {
         Injector i = new Injector();
         i.bindToOne(() -> new ReentrantReadWriteLock(), ReadWriteLock.class);
+        i.bindToOne(() -> new OWLOntologyBuilder() {
+			@Override
+			public OWLOntology createOWLOntology(OWLOntologyManager manager, OWLOntologyID ontologyID) {
+				return null;
+			}
+		}, OWLOntologyBuilder.class);
         return i;
     }
 


### PR DESCRIPTION
Fix for the issue on https://github.com/ontodev/robot/issues/1088 

When processing OWL constructs outside the OBO spec, a nasty error is generated which pollutes the Log files. This error does not affect the conversion, it just logs an error and completes the conversion successfully.

Analysis: 
This error is introduced with this commit: https://github.com/owlcs/owlapi/commit/49eaf8d3e98052e4632b6407b336956c3107ee94
> Fix is to use an injector to get a new manager to create the ontology. A manager provider would be a better solution but there are static methods and interface changes involved.

However, while injecting a new `OWLOntologyManager`, this injector was unable to initialize the `OWLOntologyBuilder` and log an error. But in the consecutive steps, ontology factories are manually set from the source manager, so execution continues successfully.

This fix introduces a dummy `OWLOntologyBuilder` to the injector. By this way the `OWLOntologyManager` is created without error and then the dummy builder is replaced with a proper one as before.

