### PR TITLE
OBO serialisation illegal axiom annotation

### DIFF
--- a/contract/src/test/java/org/obolibrary/oboformat/OBOFormatWriterTestCase.java
+++ b/contract/src/test/java/org/obolibrary/oboformat/OBOFormatWriterTestCase.java
@@ -3,6 +3,7 @@ package org.obolibrary.oboformat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -173,4 +174,21 @@ class OBOFormatWriterTestCase extends OboFormatTestBasics {
                 String.format("'%s' doesn't exist in the output file.", s)));
         }
     }
+    
+    @Test
+    void testIllegalOWLWriting() throws IOException {
+    	File illegalOWLFile = getFile("illegal_property.owl");
+    	
+        OWLOntology illegalOntology = loadOntologyFromFile(illegalOWLFile);
+        OBODoc oboDoc = convert(illegalOntology);
+        
+        OBOFormatWriter writer = new OBOFormatWriter();
+		StringWriter stringWriter = new StringWriter();
+		BufferedWriter bw = new BufferedWriter(stringWriter);
+		writer.write(oboDoc, bw);
+		
+		String illegalOutput = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#type=\"owl:Axiom\"}";
+		assertFalse(stringWriter.toString().contains(illegalOutput), String.format("Ilegal output '%s' exists in the output", illegalOutput));
+    }
+    
 }

--- a/contract/src/test/java/org/obolibrary/oboformat/OBOFormatWriterTestCase.java
+++ b/contract/src/test/java/org/obolibrary/oboformat/OBOFormatWriterTestCase.java
@@ -3,7 +3,6 @@ package org.obolibrary.oboformat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -174,21 +173,4 @@ class OBOFormatWriterTestCase extends OboFormatTestBasics {
                 String.format("'%s' doesn't exist in the output file.", s)));
         }
     }
-    
-    @Test
-    void testIllegalOWLWriting() throws IOException {
-    	File illegalOWLFile = getFile("illegal_property.owl");
-    	
-        OWLOntology illegalOntology = loadOntologyFromFile(illegalOWLFile);
-        OBODoc oboDoc = convert(illegalOntology);
-        
-        OBOFormatWriter writer = new OBOFormatWriter();
-		StringWriter stringWriter = new StringWriter();
-		BufferedWriter bw = new BufferedWriter(stringWriter);
-		writer.write(oboDoc, bw);
-		
-		String illegalOutput = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#type=\"owl:Axiom\"}";
-		assertFalse(stringWriter.toString().contains(illegalOutput), String.format("Ilegal output '%s' exists in the output", illegalOutput));
-    }
-    
 }

--- a/contract/src/test/java/org/obolibrary/oboformat/Owl2OboTestCase.java
+++ b/contract/src/test/java/org/obolibrary/oboformat/Owl2OboTestCase.java
@@ -183,20 +183,21 @@ class Owl2OboTestCase extends OboFormatTestBasics {
         assertEquals(COMMENT, comment.get().getLiteral());
     }
     
-    @Test
-    void testIllegalOWLAxiomConversion() throws IOException {
-    	File illegalOWLFile = getFile("illegal_property.owl");
-    	
-        OWLOntology illegalOntology = loadOntologyFromFile(illegalOWLFile);
-        OBODoc oboDoc = convert(illegalOntology);
-        
-        OBOFormatWriter writer = new OBOFormatWriter();
+	@Test
+	void testIllegalOWLAxiomConversion() throws IOException {
+		File illegalOWLFile = getFile("illegal_property.owl");
+
+		OWLOntology illegalOntology = loadOntologyFromFile(illegalOWLFile);
+		OBODoc oboDoc = convert(illegalOntology);
+
+		OBOFormatWriter writer = new OBOFormatWriter();
 		StringWriter stringWriter = new StringWriter();
 		BufferedWriter bw = new BufferedWriter(stringWriter);
 		writer.write(oboDoc, bw);
-		
+
 		String illegalOutput = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#type=\"owl:Axiom\"}";
-		assertFalse(stringWriter.toString().contains(illegalOutput), String.format("Ilegal output '%s' exists in the output", illegalOutput));
-    }
+		assertFalse(stringWriter.toString().contains(illegalOutput),
+				String.format("Ilegal output '%s' exists in the output", illegalOutput));
+	}
     
 }

--- a/contract/src/test/java/org/obolibrary/oboformat/Owl2OboTestCase.java
+++ b/contract/src/test/java/org/obolibrary/oboformat/Owl2OboTestCase.java
@@ -1,8 +1,13 @@
 package org.obolibrary.oboformat;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.Collection;
 import java.util.Set;
 
@@ -17,6 +22,7 @@ import org.obolibrary.oboformat.model.Clause;
 import org.obolibrary.oboformat.model.Frame;
 import org.obolibrary.oboformat.model.OBODoc;
 import org.obolibrary.oboformat.parser.OBOFormatConstants.OboFormatTag;
+import org.obolibrary.oboformat.writer.OBOFormatWriter;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationAssertionAxiom;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
@@ -176,4 +182,21 @@ class Owl2OboTestCase extends OboFormatTestBasics {
         assertTrue(comment.isPresent());
         assertEquals(COMMENT, comment.get().getLiteral());
     }
+    
+    @Test
+    void testIllegalOWLAxiomConversion() throws IOException {
+    	File illegalOWLFile = getFile("illegal_property.owl");
+    	
+        OWLOntology illegalOntology = loadOntologyFromFile(illegalOWLFile);
+        OBODoc oboDoc = convert(illegalOntology);
+        
+        OBOFormatWriter writer = new OBOFormatWriter();
+		StringWriter stringWriter = new StringWriter();
+		BufferedWriter bw = new BufferedWriter(stringWriter);
+		writer.write(oboDoc, bw);
+		
+		String illegalOutput = "{http://www.w3.org/1999/02/22-rdf-syntax-ns#type=\"owl:Axiom\"}";
+		assertFalse(stringWriter.toString().contains(illegalOutput), String.format("Ilegal output '%s' exists in the output", illegalOutput));
+    }
+    
 }

--- a/contract/src/test/resources/obo/illegal_property.owl
+++ b/contract/src/test/resources/obo/illegal_property.owl
@@ -20,7 +20,7 @@
         <rdfs:label>database_cross_reference</rdfs:label>
     </owl:AnnotationProperty>
     
-    <!-- THIS AXIOM IS ILEGAL --> 
+    <!-- THIS AXIOM IS ILLEGAL --> 
     <owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
 
     <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000006">

--- a/contract/src/test/resources/obo/illegal_property.owl
+++ b/contract/src/test/resources/obo/illegal_property.owl
@@ -1,0 +1,39 @@
+<?xml version="1.0"?>
+<rdf:RDF xmlns="http://purl.obolibrary.org/obo/fbbt/fbbt-simple.owl#"
+     xml:base="http://purl.obolibrary.org/obo/fbbt/fbbt-simple.owl"
+     xmlns:obo="http://purl.obolibrary.org/obo/"
+     xmlns:owl="http://www.w3.org/2002/07/owl#"
+     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+     xmlns:xml="http://www.w3.org/XML/1998/namespace"
+     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
+     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+     xmlns:oboInOwl="http://www.geneontology.org/formats/oboInOwl#">
+    <owl:Ontology rdf:about="http://purl.obolibrary.org/obo/fbbt/fbbt-simple.owl">
+    </owl:Ontology>
+    
+    <owl:AnnotationProperty rdf:about="http://purl.obolibrary.org/obo/IAO_0000115">
+        <obo:IAO_0000114 rdf:resource="http://purl.obolibrary.org/obo/IAO_0000122"/>
+        <rdfs:label>definition</rdfs:label>
+    </owl:AnnotationProperty>
+
+    <owl:AnnotationProperty rdf:about="http://www.geneontology.org/formats/oboInOwl#hasDbXref">
+        <rdfs:label>database_cross_reference</rdfs:label>
+    </owl:AnnotationProperty>
+    
+    <!-- THIS AXIOM IS ILEGAL --> 
+    <owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
+
+    <owl:Class rdf:about="http://purl.obolibrary.org/obo/FBbt_00000006">
+        <obo:IAO_0000115>Any segment (FBbt:00000003) that is part of some head (FBbt:00000004).</obo:IAO_0000115>
+        <oboInOwl:hasDbXref>UBERON:6000006</oboInOwl:hasDbXref>
+    </owl:Class>
+    <owl:Axiom>
+        <owl:annotatedSource rdf:resource="http://purl.obolibrary.org/obo/FBbt_00000006"/>
+        <owl:annotatedProperty rdf:resource="http://purl.obolibrary.org/obo/IAO_0000115"/>
+        <owl:annotatedTarget>Any segment (FBbt:00000003) that is part of some head (FBbt:00000004).</owl:annotatedTarget>
+        <oboInOwl:hasDbXref>FlyBase:FBrf0075072</oboInOwl:hasDbXref>
+    </owl:Axiom>
+
+</rdf:RDF>
+
+<!-- See: https://github.com/ontodev/robot/issues/1089 -->

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIOwl2Obo.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIOwl2Obo.java
@@ -1158,6 +1158,8 @@ public class OWLAPIOwl2Obo {
             }
             String value = ann.getValue().toString();
             if (prop.equals(RDFConstants.RDF_TYPE) && value.equals(OWLRDFVocabulary.OWL_AXIOM.toString())) {
+                // Guard against scenario when a syntactic triple is accidentally interpreted as an annotation.
+                // See https://github.com/ontodev/robot/issues/1089 for context
             	continue;
             }
             if (ann.getValue() instanceof OWLLiteral) {

--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIOwl2Obo.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIOwl2Obo.java
@@ -83,6 +83,7 @@ import org.semanticweb.owlapi.model.OWLSubObjectPropertyOfAxiom;
 import org.semanticweb.owlapi.model.OWLSubPropertyChainOfAxiom;
 import org.semanticweb.owlapi.model.OWLSymmetricObjectPropertyAxiom;
 import org.semanticweb.owlapi.model.OWLTransitiveObjectPropertyAxiom;
+import org.semanticweb.owlapi.rdf.rdfxml.parser.RDFConstants;
 import org.semanticweb.owlapi.vocab.Namespaces;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
 import org.semanticweb.owlapi.vocab.OWLRDFVocabulary;
@@ -1156,6 +1157,9 @@ public class OWLAPIOwl2Obo {
                 continue;
             }
             String value = ann.getValue().toString();
+            if (prop.equals(RDFConstants.RDF_TYPE) && value.equals(OWLRDFVocabulary.OWL_AXIOM.toString())) {
+            	continue;
+            }
             if (ann.getValue() instanceof OWLLiteral) {
                 value = ((OWLLiteral) ann.getValue()).getLiteral();
             } else if (ann.getValue() instanceof IRI) {


### PR DESCRIPTION
Fix for the issue: https://github.com/ontodev/robot/issues/1089

OBO serializer is adding a weird axiom annotation when an illegal annotation property is declared:

```
<owl:AnnotationProperty rdf:about="http://www.w3.org/1999/02/22-rdf-syntax-ns#type"/>
```

This fix is one of the two alternative solutions. Other alternative is: https://github.com/owlcs/owlapi/pull/1093

During OWL to OBO conversion, illegal annotation property and its value are filtered. 
