### PR TITLE
Extension of Manchester syntax to cover the whole of OWL2 DL in version 4

### DIFF
--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/AnnotatedPunningTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/annotations/AnnotatedPunningTestCase.java
@@ -11,15 +11,16 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.semanticweb.owlapi.api.test.baseclasses.TestBase;
-import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormat;
-import org.semanticweb.owlapi.formats.ManchesterSyntaxDocumentFormat;
-import org.semanticweb.owlapi.formats.RDFXMLDocumentFormat;
-import org.semanticweb.owlapi.formats.TurtleDocumentFormat;
+import org.semanticweb.owlapi.formats.FunctionalSyntaxDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.ManchesterSyntaxDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.RDFXMLDocumentFormatFactory;
+import org.semanticweb.owlapi.formats.TurtleDocumentFormatFactory;
 import org.semanticweb.owlapi.model.AxiomType;
 import org.semanticweb.owlapi.model.IRI;
 import org.semanticweb.owlapi.model.OWLAnnotationProperty;
 import org.semanticweb.owlapi.model.OWLAxiom;
 import org.semanticweb.owlapi.model.OWLDocumentFormat;
+import org.semanticweb.owlapi.model.OWLDocumentFormatFactory;
 import org.semanticweb.owlapi.model.OWLEntity;
 import org.semanticweb.owlapi.model.OWLOntology;
 
@@ -49,21 +50,21 @@ class AnnotatedPunningTestCase extends TestBase {
         List<? extends OWLEntity> entities = Arrays.asList(df.getOWLClass(iri),
             df.getOWLDatatype(iri), df.getOWLAnnotationProperty(iri), df.getOWLDataProperty(iri),
             df.getOWLObjectProperty(iri), df.getOWLNamedIndividual(iri));
-        return Arrays.asList(Arguments.of(new RDFXMLDocumentFormat(), entities),
-            Arguments.of(new TurtleDocumentFormat(), entities),
-            Arguments.of(new FunctionalSyntaxDocumentFormat(), entities),
-            Arguments.of(new ManchesterSyntaxDocumentFormat(), entities));
+        return Arrays.asList(Arguments.of(new RDFXMLDocumentFormatFactory(), entities),
+            Arguments.of(new TurtleDocumentFormatFactory(), entities),
+            Arguments.of(new FunctionalSyntaxDocumentFormatFactory(), entities),
+            Arguments.of(new ManchesterSyntaxDocumentFormatFactory(), entities));
     }
 
     @ParameterizedTest
     @MethodSource("allTests")
-    void runTestForAnnotationsOnPunnedEntitiesForFormat(OWLDocumentFormat format,
+    void runTestForAnnotationsOnPunnedEntitiesForFormat(OWLDocumentFormatFactory formatFactory,
         List<OWLEntity> entities) {
         OWLOntology o = makeOwlOntologyWithDeclarationsAndAnnotationAssertions(AP, entities);
         for (int counter = 0; counter < 10; counter++) {
-            String in = saveForRereading(o, format);
+            String in = saveForRereading(o, formatFactory.createFormat());
             m.removeOntology(o);
-            o = loadOntologyFromString(in);
+            o = loadOntologyFromString(in, formatFactory.createFormat());
         }
         assertEquals(entities.size(), o.getAxiomCount(AxiomType.ANNOTATION_ASSERTION));
     }

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/baseclasses/TestBase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/baseclasses/TestBase.java
@@ -43,7 +43,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
@@ -110,7 +109,6 @@ import org.semanticweb.owlapi.model.OWLOntologyLoaderConfiguration;
 import org.semanticweb.owlapi.model.OWLOntologyManager;
 import org.semanticweb.owlapi.model.OWLOntologyStorageException;
 import org.semanticweb.owlapi.model.OWLRuntimeException;
-import org.semanticweb.owlapi.model.OWLSubClassOfAxiom;
 import org.semanticweb.owlapi.model.parameters.Imports;
 import org.semanticweb.owlapi.util.OWLAPIPreconditions;
 import org.semanticweb.owlapi.vocab.OWL2Datatype;
@@ -386,19 +384,19 @@ public abstract class TestBase {
         axioms2 = new AnonymousIndividualsNormaliser(df).getNormalisedAxioms(ont2.getAxioms());
         OWLDocumentFormat ontologyFormat = ont2.getOWLOntologyManager().getOntologyFormat(ont2);
         applyEquivalentsRoundtrip(axioms1, axioms2, ontologyFormat);
-        if (ontologyFormat instanceof ManchesterSyntaxDocumentFormat) {
-            // drop GCIs from the expected axioms, they won't be there
-            Iterator<OWLAxiom> it = axioms1.iterator();
-            while (it.hasNext()) {
-                OWLAxiom next = it.next();
-                if (next instanceof OWLSubClassOfAxiom) {
-                    OWLSubClassOfAxiom n = (OWLSubClassOfAxiom) next;
-                    if (n.getSubClass().isAnonymous() && n.getSuperClass().isAnonymous()) {
-                        it.remove();
-                    }
-                }
-            }
-        }
+//        if (ontologyFormat instanceof ManchesterSyntaxDocumentFormat) {
+//            // drop GCIs from the expected axioms, they won't be there
+//            Iterator<OWLAxiom> it = axioms1.iterator();
+//            while (it.hasNext()) {
+//                OWLAxiom next = it.next();
+//                if (next instanceof OWLSubClassOfAxiom) {
+//                    OWLSubClassOfAxiom n = (OWLSubClassOfAxiom) next;
+//                    if (n.getSubClass().isAnonymous() && n.getSuperClass().isAnonymous()) {
+//                        it.remove();
+//                    }
+//                }
+//            }
+//        }
         PlainLiteralTypeFoldingAxiomSet a = new PlainLiteralTypeFoldingAxiomSet(axioms1);
         PlainLiteralTypeFoldingAxiomSet b = new PlainLiteralTypeFoldingAxiomSet(axioms2);
         if (!a.equals(b)) {

--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserErrorsTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/syntax/ManchesterOWLSyntaxParserErrorsTestCase.java
@@ -38,6 +38,8 @@ class ManchesterOWLSyntaxParserErrorsTestCase extends TestBase {
     void setUp() {
         OWLClass cls = mock(OWLClass.class);
         when(entityChecker.getOWLClass("C")).thenReturn(cls);
+        when(cls.isNamed()).thenReturn(true);
+        when(cls.asOWLClass()).thenReturn(cls);
         OWLClass clsC1 = mock(OWLClass.class);
         when(entityChecker.getOWLClass("C1")).thenReturn(clsC1);
         OWLObjectProperty oP = mock(OWLObjectProperty.class);

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
@@ -2249,7 +2249,7 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
                     if (j + 1 < tokens.size()) {
                         String nextToken = tokens.get(j + 1).getToken();
                         ManchesterOWLSyntax a = parse(nextToken);
-                        if (eof(nextToken) || a != null && !(a.isClassExpressionConnectiveKeyword()
+                        if (eof(nextToken) || (a != null && !(a.isClassExpressionConnectiveKeyword()
                                 || a.isClassExpressionQuantiferKeyword())) {
                             classNames.add(name);
                         }

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/parser/ManchesterOWLSyntaxParserImpl.java
@@ -332,20 +332,22 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         return new ManchesterOWLSyntaxTokenizer(s);
     }
 
-    private final Map<ManchesterOWLSyntax, AnnotatedListItemParser<OWLClass, ?>> classFrameSections =
-        new EnumMap<>(ManchesterOWLSyntax.class);
+    private final Map<ManchesterOWLSyntax, AnnotatedListItemParser<OWLClass, ?>> simpleClassFrameSections =
+            new EnumMap<>(ManchesterOWLSyntax.class);
+    private final Map<ManchesterOWLSyntax, AnnotatedListItemParser<OWLClassExpression, ?>> complexClassFrameSections =
+            new EnumMap<>(ManchesterOWLSyntax.class);
 
     private void initialiseClassFrameSections() {
-        initialiseSection(new EntityAnnotationsListItemParser<OWLClass>(), classFrameSections);
-        initialiseSection(new ClassSubClassOfListItemParser(), classFrameSections);
-        initialiseSection(new ClassEquivalentToListItemParser(), classFrameSections);
-        initialiseSection(new ClassDisjointWithListItemParser(), classFrameSections);
-        initialiseSection(new ClassHasKeyListItemParser(), classFrameSections);
-        initialiseSection(new ClassDisjointUnionOfListItemParser(), classFrameSections);
+        initialiseSection(new EntityAnnotationsListItemParser<OWLClass>(), simpleClassFrameSections);
+        initialiseSection(new ClassSubClassOfListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassEquivalentToListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassDisjointWithListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassHasKeyListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassDisjointUnionOfListItemParser(), simpleClassFrameSections);
         // Extensions
-        initialiseSection(new ClassSuperClassOfListItemParser(), classFrameSections);
-        initialiseSection(new ClassDisjointClassesListItemParser(), classFrameSections);
-        initialiseSection(new ClassIndividualsListItemParser(), classFrameSections);
+        initialiseSection(new ClassSuperClassOfListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassDisjointClassesListItemParser(), complexClassFrameSections);
+        initialiseSection(new ClassIndividualsListItemParser(), complexClassFrameSections);
     }
 
     private final Map<ManchesterOWLSyntax, AnnotatedListItemParser<OWLObjectProperty, ?>> objectPropertyFrameSections =
@@ -699,7 +701,7 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         boolean isDataPropertyName = isDataPropertyName(tok);
         boolean isObjectPropertyName = isObjectPropertyName(tok);
         if (isClassName && (isDataPropertyName || isObjectPropertyName)) {
-            if (isDataPropertyName && isObjectPropertyName) {
+            if (isDataPropertyName && isObjectPropertyName && getOntologyLoaderConfiguration().isStrict()) {
                 throw new ExceptionBuilder().withMessage(
                     "Illegal punning: " + tok + " is a data property and an object property name.")
                     .build();
@@ -1174,7 +1176,7 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
                 potentialKeywords.clear();
                 resetPossible(possible);
                 axioms.addAll(parseClassFrame());
-                possible.addAll(classFrameSections.keySet());
+                possible.addAll(simpleClassFrameSections.keySet());
             } else if (OBJECT_PROPERTY.matches(tok)) {
                 potentialKeywords.clear();
                 resetPossible(possible);
@@ -1226,11 +1228,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!DATATYPE.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(DATATYPE).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLDatatype datatype = getOWLDatatype(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
-        axioms.add(
-            new OntologyAxiomPair(defaultOntology, dataFactory.getOWLDeclarationAxiom(datatype)));
+        axioms.add(new OntologyAxiomPair(defaultOntology, dataFactory.getOWLDeclarationAxiom(datatype, annotations)));
         while (true) {
             String sect = peekToken();
             if (EQUIVALENT_TO.matches(sect)) {
@@ -1408,11 +1411,16 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!CLASS.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(CLASS).build();
         }
-        String subj = consumeToken();
-        OWLClass cls = getOWLClass(subj);
+        Set<OWLAnnotation> annotations = parseAnnotations();
+        OWLClassExpression cls = parseUnion();
         Set<OntologyAxiomPair> axioms = new HashSet<>();
-        axioms.add(new OntologyAxiomPair(defaultOntology, dataFactory.getOWLDeclarationAxiom(cls)));
-        parseFrameSections(eof, axioms, cls, classFrameSections);
+        if (cls.isNamed()) {
+            axioms.add(new OntologyAxiomPair(defaultOntology,
+                    dataFactory.getOWLDeclarationAxiom(cls.asOWLClass(), annotations)));
+            parseFrameSections(eof, axioms, cls.asOWLClass(), simpleClassFrameSections);
+        }
+
+        parseFrameSections(eof, axioms, cls, complexClassFrameSections);
         return axioms;
     }
 
@@ -1504,11 +1512,12 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
     private Set<OntologyAxiomPair> parseObjectPropertyFrame(boolean eof) {
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         consumeToken(OBJECT_PROPERTY);
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String token = consumeToken();
         OWLObjectProperty prop = getOWLObjectProperty(token);
         if (!prop.isAnonymous()) {
             axioms.add(new OntologyAxiomPair(defaultOntology,
-                dataFactory.getOWLDeclarationAxiom(prop.asOWLObjectProperty())));
+                dataFactory.getOWLDeclarationAxiom(prop.asOWLObjectProperty(), annotations)));
         }
         parseFrameSections(eof, axioms, prop, objectPropertyFrameSections);
         return axioms;
@@ -1520,11 +1529,13 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!DATA_PROPERTY.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(DATA_PROPERTY).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLDataProperty prop = getOWLDataProperty(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         axioms
-            .add(new OntologyAxiomPair(defaultOntology, dataFactory.getOWLDeclarationAxiom(prop)));
+            .add(new OntologyAxiomPair(defaultOntology, dataFactory.getOWLDeclarationAxiom(prop, annotations)));
         parseFrameSections(false, axioms, prop, dataPropertyFrameSections);
         return axioms;
     }
@@ -1535,11 +1546,13 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!ANNOTATION_PROPERTY.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(ANNOTATION_PROPERTY).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLAnnotationProperty prop = getOWLAnnotationProperty(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         for (OWLOntology ont : getOntologies()) {
-            axioms.add(new OntologyAxiomPair(ont, dataFactory.getOWLDeclarationAxiom(prop)));
+            axioms.add(new OntologyAxiomPair(ont, dataFactory.getOWLDeclarationAxiom(prop, annotations)));
         }
         parseFrameSections(false, axioms, prop, annotationPropertyFrameSections);
         return axioms;
@@ -1551,12 +1564,14 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         if (!INDIVIDUAL.matches(tok)) {
             throw new ExceptionBuilder().withKeyword(INDIVIDUAL).build();
         }
+
+        Set<OWLAnnotation> annotations = parseAnnotations();
         String subj = consumeToken();
         OWLIndividual ind = getOWLIndividual(subj);
         Set<OntologyAxiomPair> axioms = new HashSet<>();
         if (!ind.isAnonymous()) {
             axioms.add(new OntologyAxiomPair(getOntology(null),
-                dataFactory.getOWLDeclarationAxiom(ind.asOWLNamedIndividual())));
+                dataFactory.getOWLDeclarationAxiom(ind.asOWLNamedIndividual(), annotations)));
         }
         parseFrameSections(false, axioms, ind, individualFrameSections);
         return axioms;
@@ -2205,16 +2220,42 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         return IRI.create(iriString.substring(1, iriString.length() - 1));
     }
 
+    private int skipAnnotationsProcessDeclaredEntities(int start) {
+        if (start < tokens.size()) {
+            String nameToken = tokens.get(start).getToken();
+            if (ANNOTATIONS.matches(nameToken)) {
+                do {
+                    start = skipAnnotationsProcessDeclaredEntities(start + 1) + 2;
+                    nameToken = tokens.get(start).getToken();
+                } while (start < tokens.size()
+                        && (ANNOTATIONS.matches(nameToken) || COMMA.matches(nameToken)));
+            }
+        }
+
+        return start;
+    }
+
     private void processDeclaredEntities() {
+        int j = -1;
         for (int i = 0; i < tokens.size(); i++) {
             String token = tokens.get(i).getToken();
             String name = null;
-            if (i + 1 < tokens.size()) {
-                name = tokens.get(i + 1).getToken();
+            j = skipAnnotationsProcessDeclaredEntities(i + 1);
+            if (j < tokens.size()) {
+                name = tokens.get(j).getToken();
             }
             if (CLASS.matches(token)) {
                 if (name != null) {
-                    classNames.add(name);
+                    if (j + 1 < tokens.size()) {
+                        String nextToken = tokens.get(j + 1).getToken();
+                        ManchesterOWLSyntax a = parse(nextToken);
+                        if (eof(nextToken) || a != null && !(a.isClassExpressionConnectiveKeyword()
+                                || a.isClassExpressionQuantiferKeyword())) {
+                            classNames.add(name);
+                        }
+                    } else {
+                        classNames.add(name);
+                    }
                 }
             } else if (OBJECT_PROPERTY.matches(token)) {
                 if (name != null) {
@@ -3054,10 +3095,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassSubClassOfListItemParser extends AnnotatedClassExpressionListItemParser<OWLClass> {
+    class ClassSubClassOfListItemParser extends AnnotatedClassExpressionListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, OWLClassExpression o, Set<OWLAnnotation> anns) {
+        public OWLAxiom createAxiom(OWLClassExpression s, OWLClassExpression o, Set<OWLAnnotation> anns) {
             return dataFactory.getOWLSubClassOfAxiom(s, o, anns);
         }
 
@@ -3067,10 +3108,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassEquivalentToListItemParser extends AnnotatedClassExpressionListItemParser<OWLClass> {
+    class ClassEquivalentToListItemParser extends AnnotatedClassExpressionListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, OWLClassExpression o, Set<OWLAnnotation> anns) {
+        public OWLAxiom createAxiom(OWLClassExpression s, OWLClassExpression o, Set<OWLAnnotation> anns) {
             return dataFactory.getOWLEquivalentClassesAxiom(s, o, anns);
         }
 
@@ -3080,10 +3121,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassDisjointWithListItemParser extends AnnotatedClassExpressionListItemParser<OWLClass> {
+    class ClassDisjointWithListItemParser extends AnnotatedClassExpressionListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, OWLClassExpression o, Set<OWLAnnotation> anns) {
+        public OWLAxiom createAxiom(OWLClassExpression s, OWLClassExpression o, Set<OWLAnnotation> anns) {
             Set<OWLClassExpression> disjointClasses = new HashSet<>();
             disjointClasses.add(s);
             disjointClasses.add(o);
@@ -3097,10 +3138,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
     }
 
     class ClassDisjointClassesListItemParser
-        extends AnnotatedClassExpressionSetListItemParser<OWLClass> {
+        extends AnnotatedClassExpressionSetListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, Set<OWLClassExpression> o,
+        public OWLAxiom createAxiom(OWLClassExpression s, Set<OWLClassExpression> o,
             Set<OWLAnnotation> anns) {
             // o.add(s);
             return dataFactory.getOWLDisjointClassesAxiom(o, anns);
@@ -3127,10 +3168,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassHasKeyListItemParser extends AnnotatedPropertyListListItemParser<OWLClass> {
+    class ClassHasKeyListItemParser extends AnnotatedPropertyListListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, Set<OWLPropertyExpression> o,
+        public OWLAxiom createAxiom(OWLClassExpression s, Set<OWLPropertyExpression> o,
             Set<OWLAnnotation> anns) {
             return dataFactory.getOWLHasKeyAxiom(s, o, anns);
         }
@@ -3141,10 +3182,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassSuperClassOfListItemParser extends AnnotatedClassExpressionListItemParser<OWLClass> {
+    class ClassSuperClassOfListItemParser extends AnnotatedClassExpressionListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, OWLClassExpression o, Set<OWLAnnotation> anns) {
+        public OWLAxiom createAxiom(OWLClassExpression s, OWLClassExpression o, Set<OWLAnnotation> anns) {
             return dataFactory.getOWLSubClassOfAxiom(o, s, anns);
         }
 
@@ -3154,10 +3195,10 @@ public class ManchesterOWLSyntaxParserImpl implements ManchesterOWLSyntaxParser 
         }
     }
 
-    class ClassIndividualsListItemParser extends AnnotatedIndividualsListItemParser<OWLClass> {
+    class ClassIndividualsListItemParser extends AnnotatedIndividualsListItemParser<OWLClassExpression> {
 
         @Override
-        public OWLAxiom createAxiom(OWLClass s, OWLIndividual o, Set<OWLAnnotation> anns) {
+        public OWLAxiom createAxiom(OWLClassExpression s, OWLIndividual o, Set<OWLAnnotation> anns) {
             return dataFactory.getOWLClassAssertionAxiom(s, o, anns);
         }
 

--- a/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ParserException.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/manchestersyntax/renderer/ParserException.java
@@ -446,6 +446,10 @@ public class ParserException extends OWLParserException {
     @Override
     public String getMessage() {
         StringBuilder sb = new StringBuilder(1000);
+        String topMessage = super.getMessage();
+        if (topMessage != null) {
+            sb.append(topMessage).append("\n");
+        }
         sb.append("Encountered ");
         sb.append(currentToken);
         sb.append(" at line ");


### PR DESCRIPTION
In #1050 extensions to Manchester Syntax to include all features from OWL2 DL was merged for version 5. As version 4 is commonly used as well, this PR contains the same changes as #1050 for version 4 to enable a broader audience to utilize the features.