### PR TITLE
Fix forced use of `oboInOwl` namespace when translating OBO IDs.

### DIFF
--- a/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
+++ b/oboformat/src/main/java/org/obolibrary/obo2owl/OWLAPIObo2Owl.java
@@ -1694,46 +1694,35 @@ public class OWLAPIObo2Owl {
                 }
             }
         }
-        // TODO - treat_xrefs_as_equivalent
-        // special case rule for relation xrefs:
-        // 5.9.3. Special Rules for Relations
-        if (!id.contains(":")) {
+
+        String[] idParts = id.split(":", 2);
+        String uriPrefix;
+        String localId;
+        if (idParts.length > 1) { // Prefixed-ID (canonical or not)
+            localId = idParts[1];
+            uriPrefix = idSpaceMap.getOrDefault(idParts[0], DEFAULT_IRI_PREFIX + idParts[0] + '_');
+
+            // Non-canonical prefixed IDs use a '#' separator
+            // TODO - recognize all non-canonical prefixed IDs
+            if (localId.contains("_")) {
+                uriPrefix += "#";
+            }
+        } else { // Unprefixed-ID
+            // Special case for relation xrefs (5.9.3. Special Rules for Relations)
             String xid = translateShorthandIdToExpandedId(id);
             if (!xid.equals(id)) {
                 return oboIdToIRI(xid);
             }
-        }
-        String[] idParts = id.split(":", 2);
-        String db;
-        String localId;
-        if (idParts.length > 1) {
-            db = idParts[0];
-            localId = idParts[1];
-            if (localId.contains("_")) {
-                db += "#_";// NonCanonical-Prefixed-ID
-            } else {
-                db += "_";
-            }
-        } else if (idParts.length == 0) {
-            db = getDefaultIDSpace() + '#';
-            localId = id;
-        } else {// == 1
-                // todo use owlOntology IRI
-            db = getDefaultIDSpace() + '#';
-            // if(id.contains("_"))
-            // db += "_";
-            localId = idParts[0];// Unprefixed-ID
 
-        }
-        String uriPrefix;
-        if (oboInOwlDefault) {
-            uriPrefix = OIOVOCAB_IRI_PREFIX;
-        } else {
-            uriPrefix = DEFAULT_IRI_PREFIX + db;
-            if (idSpaceMap.containsKey(db)) {
-                uriPrefix = idSpaceMap.get(db);
+            localId = id;
+            if (oboInOwlDefault) {
+                uriPrefix = OIOVOCAB_IRI_PREFIX;
+            } else {
+                // TODO - use ontology ID as specified in OBO-Format 5.9.2?
+                uriPrefix = DEFAULT_IRI_PREFIX + getDefaultIDSpace() + '#';
             }
         }
+
         String safeId;
         try {
             safeId = java.net.URLEncoder.encode(localId, "US-ASCII");


### PR DESCRIPTION
This PR rewrites part of the `OWLAPIObo2Owl#oboIdToIRI_load()` method so that the `oboInOwlDefault` parameter is only used when translating unprefixed IDs (where it instructs to create an IRI in the oboInOwl namespace instead of the ontology's default namespace). When translating a prefixed ID, the IRI to construct should always use the URL prefix dictated by the prefix name.

closes #1112