### PR TITLE
Ontology iri fix for owl api version 4

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -190,6 +190,8 @@ public class OWLRDFConsumer
     private final Map<IRI, IRI> ontologyVersions = new HashMap<>();
     /** IRIs that had a type triple to owl:Ontology */
     private final Set<IRI> ontologyIRIs;
+    /** IRIs that represent a subject for predicate owl:imports  */
+    private final Set<IRI> ontologySubImportIRIs;
     /** IRIs that had a type triple to owl:Restriction */
     private final Set<IRI> restrictionIRIs;
     /** Maps rdf:next triple subjects to objects */
@@ -294,6 +296,7 @@ public class OWLRDFConsumer
         propertyIRIs = CollectionFactory.createSet();
         restrictionIRIs = CollectionFactory.createSet();
         ontologyIRIs = CollectionFactory.createSet();
+        ontologySubImportIRIs = CollectionFactory.createSet();
         listFirstLiteralTripleMap = CollectionFactory.createMap();
         listFirstResourceTripleMap = CollectionFactory.createMap();
         listRestTripleMap = CollectionFactory.createMap();
@@ -1467,7 +1470,8 @@ public class OWLRDFConsumer
             for (OWLAnnotation anno : ontology.getAnnotations()) {
                 if (anno.getValue() instanceof IRI) {
                     IRI iri = (IRI) anno.getValue();
-                    if (ontologyIRIs.contains(iri)) {
+                    if (ontologyIRIs.contains(iri)
+                        && !ontologySubImportIRIs.contains(iri)) {
                         candidateIRIs.remove(iri);
                     }
                 }
@@ -2285,14 +2289,28 @@ public class OWLRDFConsumer
 
     /**
      * Adds the ontology.
-     * 
+     *
      * @param iri the iri
+     * @param owlImportSubject Is the iri used as subject for predicate
+     *                         owl:imports
      */
-    protected void addOntology(IRI iri) {
+    protected void addOntology(IRI iri, boolean owlImportSubject) {
         if (ontologyIRIs.isEmpty()) {
             firstOntologyIRI = iri;
         }
+        if (owlImportSubject) {
+            ontologySubImportIRIs.add(iri);
+        }
         ontologyIRIs.add(iri);
+    }
+    /**
+     * Overload method of addOntology with
+     * no owl:import subject iri
+     *
+     * @param iri the iri
+     */
+    protected void addOntology(IRI iri) {
+        addOntology(iri, false);
     }
 
     /**

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
@@ -1638,7 +1638,7 @@ public class TripleHandlers {
         @Override
         public void handleTriple(IRI subject, IRI predicate, IRI object) {
             consumeTriple(subject, predicate, object);
-            consumer.addOntology(subject);
+            consumer.addOntology(subject, true);
             consumer.addOntology(object);
             OWLImportsDeclaration importsDeclaration = df.getOWLImportsDeclaration(object);
             consumer.addImport(importsDeclaration);


### PR DESCRIPTION
This fix adds a condition to check wether the parsed IRIs are used as subject for `owl:imports`. This fixes #1080 for owl api version 4.

In specific I made it for version 4 as I am using protege 5.6  which uses owl api 4.5.26

<img src="https://github.com/owlcs/owlapi/assets/47216966/27c2bfce-51c5-4f82-8e60-3261da15fb7b" alt=""  width="400" height="400" />

It is based on the solution from here https://github.com/owlcs/owlapi/issues/1080#issuecomment-1826185972

Feel free to add comments or improvements. 

