### PR TITLE
Handle possible exception when comparing integer literals.

### DIFF
--- a/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestCornerCasesTestCase.java
+++ b/contract/src/test/java/org/semanticweb/owlapi/api/test/literals/TestCornerCasesTestCase.java
@@ -111,4 +111,11 @@ class TestCornerCasesTestCase extends TestBase {
         assertTrue(saveOntology(o).toString().contains("-INF"));
         equal(o, roundTrip(o));
     }
+
+    @Test
+    void testCompareWithLargeInteger() {
+        OWLLiteral smallInteger = df.getOWLLiteral(123);
+        OWLLiteral largeInteger = df.getOWLLiteral("149597870700", df.getIntegerOWLDatatype());
+        assertFalse(smallInteger.equals(largeInteger));
+    }
 }

--- a/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplInteger.java
+++ b/impl/src/main/java/uk/ac/manchester/cs/owl/owlapi/OWLLiteralImplInteger.java
@@ -167,9 +167,14 @@ public class OWLLiteralImplInteger extends OWLObjectImplWithoutEntityAndAnonCach
             return literal == other.literal;
         }
         if (obj instanceof OWLLiteral) {
-            return ((OWLLiteral) obj).isInteger()
-                && ((OWLLiteral) obj).getLiteral().charAt(0) != '0'
-                && literal == ((OWLLiteral) obj).parseInteger();
+            OWLLiteral other = (OWLLiteral) obj;
+            if (other.isInteger() && other.getLiteral().charAt(0) != '0') {
+                try {
+                    return literal == other.parseInteger();
+                } catch (NumberFormatException e) {
+                    return getLiteral().equals(other.getLiteral());
+                }
+            }
         }
         return false;
     }


### PR DESCRIPTION
This PR is a putative fix for #1126, where a `NumberFormatException` can be raised when trying to compare integer values if one of the values is too large fit into a Java integer.

The fix is simply to catch the exception and fall back to comparing the integers based on their string literal representations.