### PR TITLE
Fixed ontology iri parsing (version5) when annotation imports same iri

### DIFF
--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/OWLRDFConsumer.java
@@ -245,6 +245,8 @@ public class OWLRDFConsumer
      * IRIs that had a type triple to owl:Ontology
      */
     private final Set<IRI> ontologyIRIs = createSet();
+    /** IRIs that represent a subject for predicate owl:imports  */
+    private final Set<IRI> ontologySubImportIRIs = createSet();
     /**
      * IRIs that had a type triple to owl:Restriction
      */
@@ -1467,7 +1469,8 @@ public class OWLRDFConsumer
             // Choose one that isn't the object of an annotation assertion
             Set<IRI> candidateIRIs = createSet(ontologyIRIs);
             ontology.annotations().forEach(a -> a.getValue().asIRI().ifPresent(iri -> {
-                if (ontologyIRIs.contains(iri)) {
+                if (ontologyIRIs.contains(iri)
+                    && !ontologySubImportIRIs.contains(iri)) {
                     candidateIRIs.remove(iri);
                 }
             }));
@@ -2212,12 +2215,27 @@ public class OWLRDFConsumer
      * Adds the ontology.
      *
      * @param iri the iri
+     * @param owlImportSubject Is the iri used as subject for predicate
+     *                         owl:imports
      */
-    protected void addOntology(IRI iri) {
+    protected void addOntology(IRI iri, boolean owlImportSubject) {
         if (ontologyIRIs.isEmpty()) {
             firstOntologyIRI = iri;
         }
+        if (owlImportSubject) {
+            ontologySubImportIRIs.add(iri);
+        }
         ontologyIRIs.add(iri);
+    }
+
+    /**
+     * Overload method of addOntology with
+     * no owl:import subject iri
+     *
+     * @param iri the iri
+     */
+    protected void addOntology(IRI iri) {
+        addOntology(iri, false);
     }
 
     /**

--- a/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
+++ b/parsers/src/main/java/org/semanticweb/owlapi/rdf/rdfxml/parser/TripleHandlers.java
@@ -1546,7 +1546,7 @@ public class TripleHandlers {
         @Override
         public void handleTriple(IRI s, IRI p, IRI o) {
             consume(s, p, o);
-            consumer.addOntology(s);
+            consumer.addOntology(s, true);
             consumer.addOntology(o);
             OWLImportsDeclaration id = df.getOWLImportsDeclaration(o);
             consumer.addImport(id);


### PR DESCRIPTION
First of all thanks for merging the fix I provided in https://github.com/owlcs/owlapi/pull/1117.

I have also added this same fix for version 5.