### PR TITLE
osgi: Do not require SLF4J version 2 or later.

### DIFF
--- a/osgidistribution/pom.xml
+++ b/osgidistribution/pom.xml
@@ -133,6 +133,8 @@
 							com.google.common.util.concurrent;version="[18.0,32)",
 							javax.inject;version="[1.0,2)",
 							javax.annotation;version=!,
+							org.slf4j;version="[1.0,3)",
+							!org.slf4j.spi,
 							*
 						</Import-Package>
 					</instructions>


### PR DESCRIPTION
The client side of the SLF4J API is backwards compatible, so even if the OWLAPI is compiled against `slf4j-api` version 2.x (currently 2.0.11), it can still be used in a program that provides `slf4j-api` version 1.x.

But the OSGi distribution of OWLAPI is forcefully requiring `slf4j-api` version 2.0 at a minimum, because the Apache Felix maven-bundle-plugin is automatically inserting the following instruction in the manifest of the owlapi-osgidistribution archive:

```
Import-Package: […],org.slf4j;version=[2.0,3),org.slf4j.spi;version="[2.0,3)",[…]
```

thereby forcing any OSGi application to upgrade to SLF4J 2.x in order to keep using the OWLAPI.

This PR amends the configuration of the maven-bundle-plugin to explicitly insert Import-Package instructions that (1) accept both versions 1.x and 2.x of `slf4j-api` and (2) do not require the `org.slf4j.spi` package (which is only needed for SLF4J 2.x).